### PR TITLE
Address `cargo run` warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Pool, Row, Sqlite, SqliteExecutor, Transaction};
-use tokio::task;
 
 lazy_static! {
     static ref EMAIL_RE_1: Regex =
@@ -66,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Some kind of exponential backpressure on a worker would be nicer
-    let mut retries = 0;
+    let retries = 0;
     loop {
         // TODO: lol handle these better, i keep getting deadlocks but wanna just churn some emails
         // retries += 1;


### PR DESCRIPTION
```bash
$ cargo run
   Compiling gmail_stats v0.1.0 (<filepath>)
warning: unused import: `tokio::task`
  --> src/main.rs:10:5
   |
10 | use tokio::task;
   |     ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: variable does not need to be mutable
  --> src/main.rs:69:9
   |
69 |     let mut retries = 0;
   |         ----^^^^^^^
   |         |
   |         help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default
```