### PR TITLE
Refactor get_sender(): single case-insensitive pass over a header priority list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -252,57 +252,26 @@ fn cleanup_sender(sender: String) -> String {
 }
 
 fn get_sender(message: &Message) -> anyhow::Result<String> {
-    let mut from_headers = message
-        .clone()
+    // Header names are case-insensitive (RFC 5322); check candidates in priority order.
+    const CANDIDATES: [&str; 2] = ["from", "return-path"];
+    let headers = message
         .payload
-        .unwrap_or_default()
-        .headers
-        .unwrap_or_default()
-        .iter()
-        .filter(|header| header.name == Some("From".to_string()))
-        .cloned()
-        .collect::<Vec<_>>();
+        .as_ref()
+        .and_then(|p| p.headers.as_deref())
+        .unwrap_or(&[]);
 
-    if from_headers.is_empty() {
-        from_headers = message
-            .clone()
-            .payload
-            .unwrap_or_default()
-            .headers
-            .unwrap_or_default()
-            .iter()
-            .filter(|header| header.name == Some("FROM".to_string()))
-            .cloned()
-            .collect::<Vec<_>>();
-
-        // TODO: lol this is dumb, should have a Vec<String> of headers instead of this weird mess
-        if from_headers.is_empty() {
-            from_headers = message
-                .clone()
-                .payload
-                .unwrap_or_default()
-                .headers
-                .unwrap_or_default()
-                .iter()
-                .filter(|header| header.name == Some("Return-Path".to_string()))
-                .cloned()
-                .collect::<Vec<_>>();
-
-            if from_headers.is_empty() {
-                println!("weird email without from header: {:?}", message);
-                return Ok("".to_string());
-            }
+    for candidate in CANDIDATES {
+        if let Some(value) = headers.iter().find_map(|header| {
+            header
+                .name
+                .as_deref()
+                .filter(|name| name.eq_ignore_ascii_case(candidate))
+                .and(header.value.as_deref())
+        }) {
+            return Ok(value.to_string());
         }
-        return Ok(from_headers[0]
-            .value
-            .as_ref()
-            .expect("expected sender for mail")
-            .to_string());
     }
 
-    Ok(from_headers[0]
-        .value
-        .as_ref()
-        .expect("expected sender for mail")
-        .to_string())
+    println!("weird email without from header: {:?}", message.id);
+    Ok(String::new())
 }


### PR DESCRIPTION
Closes #4

## Summary

- Rewrote `get_sender()` as a single borrow-only pass: headers are obtained via `message.payload.as_ref().and_then(|p| p.headers.as_deref()).unwrap_or(&[])`, then an ordered candidate list `["from", "return-path"]` is checked with `eq_ignore_ascii_case` and `find_map`. No `message.clone()` or per-candidate re-collection remains.
- Case-insensitive matching subsumes the separate `"From"`/`"FROM"` branches while preserving priority: any casing of From wins over Return-Path.
- Removed the `.expect("expected sender for mail")` panic — a header with a name but no value is now treated the same as a missing header and falls through to the next candidate.
- The empty-headers fallback now logs only `message.id` instead of debug-printing the entire message.

## Behavior note

A message with an empty-valued `From` and a populated `Return-Path` previously panicked; it now falls through to `Return-Path`. Otherwise sender extraction results are unchanged.

## Verification

- `cargo build` succeeds.
- `cargo clippy` introduces no new warnings (the two pre-existing warnings on main — unused `tokio::task` import and an unused `mut` — are untouched).
- Not runtime-tested: the app requires Gmail OAuth credentials, so I could not run it end-to-end to compare sender counts on a real mailbox. That acceptance criterion should be checked with a real run.
