### PR TITLE
Add CI: cargo build, test, and clippy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Pool, Row, Sqlite, SqliteExecutor, Transaction};
-use tokio::task;
 
 type GmailHub =
     Gmail<hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>>;
@@ -67,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Some kind of exponential backpressure on a worker would be nicer
-    let mut retries = 0;
+    let retries = 0;
     loop {
         // TODO: lol handle these better, i keep getting deadlocks but wanna just churn some emails
         // retries += 1;


### PR DESCRIPTION
Closes #9

## Summary
- Adds `.github/workflows/ci.yml` running on pushes to `main` and on all PRs: `cargo build --verbose`, `cargo test --verbose`, and `cargo clippy --all-targets -- -D warnings`, on the stable toolchain with `Swatinem/rust-cache` for speed.
- Since clippy denies warnings, the two pre-existing warnings on `main` are fixed here so CI starts green: removed the unused `tokio::task` import and the unused `mut` on `retries` (both leftovers of the disabled concurrency code). Note these lines are also touched by #7/#8, so whichever merges second will have a trivial conflict.

## Testing
- Ran all three CI steps locally in the worktree: build and test pass, clippy is clean with `-D warnings`.
