### PR TITLE
Deploy static demo site with synthetic data to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "demo/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: demo
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gmail-stats
 Generate stats on your GMail inbox and store in a SQLite database
 
+**[Live demo](https://zbuc.github.io/gmail-stats/)** — a static demo of the web viewer with synthetic data for a fictional account (no real inbox involved).
+
 # What?
 My GMail inbox was a mess and there's no easy built-in way to view things like who the most frequent senders of mail are.
 

--- a/demo/app.css
+++ b/demo/app.css
@@ -1,0 +1,93 @@
+:root {
+  --bg: #fafafa;
+  --fg: #1a1a1a;
+  --muted: #6b6b6b;
+  --card: #ffffff;
+  --border: #e2e2e2;
+  --accent: #2563eb;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #16181d;
+    --fg: #e8e8e8;
+    --muted: #9a9a9a;
+    --card: #1f2229;
+    --border: #33363e;
+    --accent: #7aa2f7;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+}
+main { max-width: 60rem; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+h1 { font-size: 1.4rem; margin: 0 0 1rem; }
+h1 span { color: var(--muted); font-weight: normal; font-size: 1rem; }
+.hidden { display: none; }
+.muted { color: var(--muted); }
+
+.tiles { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1.5rem; }
+.tile {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  min-width: 10rem;
+  flex: 1 1 10rem;
+}
+.tile .label { font-size: 0.8rem; color: var(--muted); }
+.tile .value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.tile .value.small { font-size: 1.05rem; }
+
+table { width: 100%; border-collapse: collapse; background: var(--card);
+        border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+th, td { text-align: left; padding: 0.45rem 0.75rem; border-top: 1px solid var(--border); }
+thead th { border-top: none; background: var(--card); font-size: 0.8rem;
+           text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+td.sender { overflow-wrap: anywhere; }
+
+.notice {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+.notice h2 { margin-top: 0; font-size: 1.1rem; }
+pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.75rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+}
+button {
+  font: inherit;
+  color: var(--fg);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+}
+button:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Demo-only additions (not in the local viewer's stylesheet) */
+.demo-banner {
+  background: color-mix(in srgb, var(--accent) 12%, var(--card));
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 0.6rem 0.9rem;
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+}
+a { color: var(--accent); }

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,0 +1,77 @@
+"use strict";
+
+// Vendored from the local viewer (web/app.js on the issue-11 branch), with
+// the server-specific parts removed: data is a static ./summary.json, so
+// there is no "missing DB" setup flow and no server error envelope.
+// Sender strings are still only ever rendered via textContent — never
+// innerHTML — to keep parity with the viewer's handling of untrusted input.
+
+const views = ["loading", "error", "stats"];
+
+function showView(name) {
+  for (const id of views) {
+    document.getElementById(id).classList.toggle("hidden", id !== name);
+  }
+}
+
+function showError(message) {
+  document.getElementById("error-message").textContent = message;
+  showView("error");
+}
+
+function render(data) {
+  const senders = Array.isArray(data.senders) ? data.senders : [];
+
+  document.getElementById("total-messages").textContent =
+    Number(data.total_messages || 0).toLocaleString();
+  document.getElementById("distinct-senders").textContent =
+    senders.length.toLocaleString();
+  document.getElementById("top-sender").textContent =
+    senders.length > 0 ? senders[0].sender : "—";
+
+  const tbody = document.getElementById("sender-rows");
+  tbody.replaceChildren();
+  for (const row of senders) {
+    const tr = document.createElement("tr");
+    const senderCell = document.createElement("td");
+    senderCell.className = "sender";
+    senderCell.textContent = row.sender;
+    const countCell = document.createElement("td");
+    countCell.className = "num";
+    countCell.textContent = Number(row.mails_sent || 0).toLocaleString();
+    tr.append(senderCell, countCell);
+    tbody.appendChild(tr);
+  }
+
+  const generated = document.getElementById("generated-at");
+  if (data.generated_at_unix) {
+    generated.textContent =
+      "Synthetic data generated " +
+      new Date(data.generated_at_unix * 1000).toLocaleDateString();
+  } else {
+    generated.textContent = "";
+  }
+
+  showView("stats");
+}
+
+async function load() {
+  showView("loading");
+  let response;
+  let body;
+  try {
+    response = await fetch("./summary.json");
+    body = await response.json();
+  } catch (err) {
+    showError("Could not load the demo data.");
+    return;
+  }
+  if (!response.ok) {
+    showError("Could not load the demo data.");
+    return;
+  }
+  render(body);
+}
+
+document.getElementById("retry-error").addEventListener("click", load);
+load();

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>gmail-stats · demo</title>
+<!-- Static demo of the gmail-stats local viewer (see web/ on the issue-11
+     branch). Vendored copy: paths are relative for GitHub Pages, data comes
+     from ./summary.json instead of the local server's /api/summary. -->
+<link rel="stylesheet" href="./app.css">
+<script src="./app.js" defer></script>
+</head>
+<body>
+<main>
+  <div class="demo-banner">
+    Demo — all data on this page is synthetic, for a fictional Gmail account.
+    No real inbox was scanned.
+  </div>
+
+  <h1>gmail-stats <span>· public demo</span></h1>
+
+  <section id="loading">
+    <p class="muted">Loading&hellip;</p>
+  </section>
+
+  <section id="error" class="notice hidden">
+    <h2>Something went wrong</h2>
+    <p id="error-message"></p>
+    <button id="retry-error" type="button">Retry</button>
+  </section>
+
+  <section id="stats" class="hidden">
+    <div class="tiles">
+      <div class="tile">
+        <div class="label">Total messages</div>
+        <div class="value" id="total-messages"></div>
+      </div>
+      <div class="tile">
+        <div class="label">Distinct senders</div>
+        <div class="value" id="distinct-senders"></div>
+      </div>
+      <div class="tile">
+        <div class="label">Top sender</div>
+        <div class="value small" id="top-sender"></div>
+      </div>
+    </div>
+    <table>
+      <thead>
+        <tr><th>Sender</th><th class="num">Messages</th></tr>
+      </thead>
+      <tbody id="sender-rows"></tbody>
+    </table>
+    <p class="muted" id="generated-at"></p>
+    <p class="muted">
+      This is a static demo of the
+      <a href="https://github.com/zbuc/gmail-stats">gmail-stats</a> local web
+      viewer, populated with synthetic data. All sender addresses use reserved
+      example domains; no real email data is involved.
+    </p>
+  </section>
+</main>
+</body>
+</html>

--- a/demo/summary.json
+++ b/demo/summary.json
@@ -1,0 +1,21 @@
+{
+  "total_messages": 2128,
+  "generated_at_unix": 1784678400,
+  "senders": [
+    { "sender": "newsletter@deals.shopping.example", "mails_sent": 412 },
+    { "sender": "notifications@social.example", "mails_sent": 388 },
+    { "sender": "no-reply@updates.example.com", "mails_sent": 265 },
+    { "sender": "alerts@bank.example", "mails_sent": 198 },
+    { "sender": "digest@news.example.org", "mails_sent": 187 },
+    { "sender": "team@project.example.net", "mails_sent": 154 },
+    { "sender": "receipts@store.example", "mails_sent": 112 },
+    { "sender": "support@service.example.com", "mails_sent": 96 },
+    { "sender": "alice@example.org", "mails_sent": 84 },
+    { "sender": "bob@example.net", "mails_sent": 61 },
+    { "sender": "promo@travel.example", "mails_sent": 57 },
+    { "sender": "security@accounts.example", "mails_sent": 43 },
+    { "sender": "calendar@invites.example", "mails_sent": 31 },
+    { "sender": "carol@example.com", "mails_sent": 26 },
+    { "sender": "hello@startup.example", "mails_sent": 14 }
+  ]
+}


### PR DESCRIPTION
Closes #15

Implements the design posted on the issue (static export — see [the design comment](https://github.com/zbuc/gmail-stats/issues/15#issuecomment-5041563126) for the alternatives considered and trade-offs).

## Summary
- `demo/` — self-contained static site: the web viewer UI vendored from the issue-11 branch (PR #14), with `app.js` fetching a committed `./summary.json` instead of the live `/api/summary`, relative asset paths for the Pages subpath, the server-only "missing DB" flow removed, and a visible banner + footer stating the data is synthetic.
- `demo/summary.json` — the fictional dummy account's dataset: 15 senders, all on RFC 2606 reserved example domains, counts internally consistent (sum = `total_messages` = 2,128) and sorted descending to match the API contract.
- `.github/workflows/pages.yml` — deploys `demo/` via `actions/upload-pages-artifact` + `actions/deploy-pages` on pushes to `main` touching `demo/**` (plus `workflow_dispatch`).
- README links the demo.
- Pages is already enabled on the repo with `build_type=workflow` (done via `gh api` as part of this work), so the site will go live at https://zbuc.github.io/gmail-stats/ on the first deploy after merge.

## Testing
- Data validated programmatically: sum of sender counts equals `total_messages`, counts sorted descending, every domain is a reserved example domain.
- Rendered the site in headless Chrome against a local static server: all 15 sender rows populate, tiles show correct totals, loading state hides, no server dependency.
- The Pages workflow itself only runs on `main`, so the first real deploy happens on merge (`workflow_dispatch` is available as a manual fallback).

## Caveats
- `demo/` duplicates the viewer assets until PR #14 merges; the issue's design comment describes the follow-up to generate the demo from `web/` at deploy time instead.
