### PR TITLE
Viewer: page-size selector (25/50/100/500)

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -117,3 +117,11 @@ tr.hidden-row td.act { opacity: 1; }
 }
 .pager button:disabled { opacity: 0.4; cursor: default; }
 .pager button:disabled:hover { border-color: var(--border); color: var(--fg); }
+.toggle select {
+  font: inherit;
+  color: var(--fg);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.25rem 0.4rem;
+}

--- a/web/app.js
+++ b/web/app.js
@@ -3,8 +3,10 @@
 // Sender strings come from arbitrary From: headers and are attacker-controlled.
 // This page only ever renders them via textContent — never innerHTML.
 
-const PAGE_SIZE = 50;
+const PAGE_SIZES = [25, 50, 100, 500];
+const DEFAULT_PAGE_SIZE = 50;
 const HIDDEN_KEY = "gmail-stats.hiddenSenders";
+const PAGE_SIZE_KEY = "gmail-stats.pageSize";
 
 const views = ["loading", "setup", "error", "stats"];
 
@@ -12,9 +14,19 @@ const state = {
   data: null,
   query: "",
   page: 1,
+  pageSize: loadPageSize(),
   showHidden: false,
   hidden: loadHidden(),
 };
+
+function loadPageSize() {
+  try {
+    const stored = Number(localStorage.getItem(PAGE_SIZE_KEY));
+    return PAGE_SIZES.includes(stored) ? stored : DEFAULT_PAGE_SIZE;
+  } catch (err) {
+    return DEFAULT_PAGE_SIZE;
+  }
+}
 
 function loadHidden() {
   try {
@@ -107,10 +119,10 @@ function update() {
     listed = listed.filter(row => String(row.sender).toLowerCase().includes(query));
   }
 
-  const pages = Math.max(1, Math.ceil(listed.length / PAGE_SIZE));
+  const pages = Math.max(1, Math.ceil(listed.length / state.pageSize));
   state.page = Math.min(Math.max(1, state.page), pages);
-  const start = (state.page - 1) * PAGE_SIZE;
-  const pageRows = listed.slice(start, start + PAGE_SIZE);
+  const start = (state.page - 1) * state.pageSize;
+  const pageRows = listed.slice(start, start + state.pageSize);
 
   const tbody = document.getElementById("sender-rows");
   tbody.replaceChildren();
@@ -166,6 +178,18 @@ document.getElementById("retry-setup").addEventListener("click", load);
 document.getElementById("retry-error").addEventListener("click", load);
 document.getElementById("search").addEventListener("input", event => {
   state.query = event.target.value;
+  state.page = 1;
+  update();
+});
+document.getElementById("page-size").value = String(state.pageSize);
+document.getElementById("page-size").addEventListener("change", event => {
+  const size = Number(event.target.value);
+  state.pageSize = PAGE_SIZES.includes(size) ? size : DEFAULT_PAGE_SIZE;
+  try {
+    localStorage.setItem(PAGE_SIZE_KEY, String(state.pageSize));
+  } catch (err) {
+    // Storage unavailable — selection just won't survive reload.
+  }
   state.page = 1;
   update();
 });

--- a/web/index.html
+++ b/web/index.html
@@ -55,6 +55,14 @@ $ cargo run</pre>
     </div>
     <div class="controls">
       <input id="search" type="search" placeholder="Filter senders&hellip;" autocomplete="off">
+      <label class="toggle">Rows
+        <select id="page-size">
+          <option value="25">25</option>
+          <option value="50" selected>50</option>
+          <option value="100">100</option>
+          <option value="500">500</option>
+        </select>
+      </label>
       <label class="toggle"><input id="show-hidden" type="checkbox"> Show hidden</label>
     </div>
     <table>


### PR DESCRIPTION
Closes #23

## Summary
Adds a "Rows" selector next to the search box: 25/50/100/500, default 50. Changing it resets to page 1, and the selection persists in localStorage alongside the hidden-senders list. Front-end only (`web/`), so the Pages demo inherits it via the deploy-time build (#20, now merged — this PR will trigger a demo redeploy on merge).

This commit was originally pushed to the issue-21 branch after PR #22 had already merged, so it never reached main; this is the same change cherry-picked onto current main.

## Testing
- Headless Chrome harness against the 84k dataset: 25 → 57 pages, 50 → 29, 100 → 15, 500 → 3, correct row counts and prev/next states at each size, page 2 navigation at 100/page, and the stored value round-trips through localStorage.
- `demo/build_demo.py` on current main transforms the updated assets cleanly (anchors intact, selector present in the built demo).