### PR TITLE
Cross-source rfc_message_id dedupe and mixed-sources banner retirement (Phase D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ Choose the **API scan** if you can OAuth and want to re-scan incrementally;
 choose the **Takeout import** if you're enrolled in Advanced Protection, don't
 want to create a Cloud project, or already have an export lying around.
 
-> **Warning: don't mix both modes into one database (yet).** The scan keys
-> messages by Gmail's internal id and the importer by RFC `Message-ID`, so a
-> message ingested by both is counted twice. Each mode on its own is fully
-> idempotent — re-running never double-counts. Cross-source dedupe is planned
-> (Phase D of [#26](https://github.com/zbuc/gmail-stats/issues/26)); until it
-> lands, use separate `--db` files if you want both.
+Both modes can share one database: messages are deduplicated across sources
+by their RFC `Message-ID` header, so scanning and importing overlapping mail
+counts each message once. One caveat for databases with scans that predate
+this dedupe (the scanner didn't record Message-IDs back then): run the
+[backfill repair pass](#repairing-cross-source-duplicates) once to fetch the
+missing Message-IDs and collapse any historical double counts. The web viewer
+shows a banner with the exact command whenever that applies.
 
 ## Option A: Gmail API scan (OAuth)
 
@@ -108,11 +109,41 @@ Resume validates that the file hasn't changed (size, mtime, content
 fingerprint); if it has, it safely falls back to re-parsing from the start,
 which stays correct thanks to the dedupe.
 
+## Repairing cross-source duplicates
+
+The scan and the import key `seen_mails` differently (Gmail's internal id vs.
+`mid:`-prefixed RFC `Message-ID`), so cross-source dedupe works through a
+shared `rfc_message_id` column: both ingesters record each message's
+normalized Message-ID and check it before counting, and a message ingested by
+both sources is counted exactly once. Messages without any Message-ID are
+simply counted per source, as before.
+
+Scans that ran before this feature existed didn't record Message-IDs, so a
+database that mixed such scans with an import may hold double counts. Repair
+it once with:
+
+```console
+$ cargo run -- scan --backfill-message-ids
+```
+
+This is a normal ingest run (it takes the same lock, writes a run row, and
+shows progress in the web viewer). It fetches just the missing `Message-ID`
+headers over the Gmail API — using the same OAuth credentials, rate limiting,
+and retries as a scan — then collapses every message found in both sources by
+decrementing the affected sender count once per duplicate. It is idempotent
+and resumable: interrupt it any time and re-run the same command to continue;
+a fully repaired database finishes immediately without touching the network.
+The web viewer's duplicate-counts banner disappears once the repair is
+complete.
+
 ## Command line
 
 ```
 gmail_stats [scan] [OPTIONS]           scan Gmail over the API (OAuth; the default)
 gmail_stats import <PATH> [OPTIONS]    import a Google Takeout mbox export
+gmail_stats scan --backfill-message-ids [OPTIONS]
+                                       fetch Message-IDs for earlier scans and collapse
+                                       cross-source duplicate counts (idempotent)
 
 --db <PATH>            SQLite database path        [env: GMAIL_STATS_DB] [default: stats.db]
 --credentials <PATH>   OAuth client secret (scan)  [env: GMAIL_STATS_CREDENTIALS] [default: credentials.json]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -14,8 +14,10 @@ use tokio::time::MissedTickBehavior;
 
 /// The schema version this binary knows how to produce, tracked in
 /// `PRAGMA user_version`. The pre-versioning tables (`seen_mails`, `senders`)
-/// are the version-0 baseline; migration 1 adds `ingest_runs`.
-pub const SCHEMA_VERSION: i64 = 1;
+/// are the version-0 baseline; migration 1 adds `ingest_runs`; migration 2
+/// adds `seen_mails.rfc_message_id` for cross-source dedupe (issue #26
+/// Phase D).
+pub const SCHEMA_VERSION: i64 = 2;
 
 pub fn now_unix() -> i64 {
     SystemTime::now()
@@ -99,7 +101,79 @@ pub async fn migrate(conn: &mut SqliteConnection) -> anyhow::Result<()> {
         tx.commit().await?;
     }
 
+    if version < 2 {
+        // Migration 2: the rfc_message_id column that unifies the two
+        // seen_mails keyspaces (bare Gmail ids from API scans, `mid:`-prefixed
+        // RFC Message-IDs from mbox imports). Nullable — NULL means "not
+        // known yet" for scan rows (repaired by `scan --backfill-message-ids`)
+        // and stays NULL forever for messages that genuinely have no
+        // Message-ID. Non-unique index: duplicate Message-IDs are data, the
+        // dedupe check just needs the lookup to be cheap.
+        //
+        // `mid:` rows embed their Message-ID in the key itself, so they are
+        // populated right here with the same normalization the ingesters use;
+        // only bare Gmail rows need the API backfill afterwards.
+        let mut tx = conn.begin().await?;
+        sqlx::query("ALTER TABLE seen_mails ADD COLUMN rfc_message_id TEXT")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS seen_mails_rfc_message_id \
+             ON seen_mails (rfc_message_id)",
+        )
+        .execute(&mut *tx)
+        .await?;
+        loop {
+            let batch: Vec<String> = sqlx::query_scalar(
+                "SELECT mail_id FROM seen_mails \
+                 WHERE mail_id LIKE 'mid:%' AND rfc_message_id IS NULL LIMIT 10000",
+            )
+            .fetch_all(&mut *tx)
+            .await?;
+            if batch.is_empty() {
+                break;
+            }
+            for mail_id in batch {
+                let normalized = normalize_rfc_message_id(&mail_id["mid:".len()..]);
+                // A mid: key whose embedded id normalizes to nothing would be
+                // unreachable by the dedupe check either way; the empty-string
+                // marker below just keeps this loop from revisiting the row.
+                sqlx::query("UPDATE seen_mails SET rfc_message_id = ? WHERE mail_id = ?")
+                    .bind(normalized.unwrap_or_default())
+                    .bind(&mail_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+        sqlx::query("PRAGMA user_version = 2")
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+    }
+
     Ok(())
+}
+
+/// Normalize an RFC 5322 Message-ID for cross-source comparison: trim
+/// whitespace, strip one pair of enclosing angle brackets, trim again.
+/// Case is preserved (the left-hand side of a Message-ID is case-sensitive).
+/// Returns None when nothing usable remains — such messages are never deduped
+/// across sources.
+///
+/// This is the single shared normalization used by the API scanner, the mbox
+/// importer, the migration that populates `mid:` rows, and the backfill.
+pub fn normalize_rfc_message_id(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let inner = trimmed
+        .strip_prefix('<')
+        .and_then(|s| s.strip_suffix('>'))
+        .unwrap_or(trimmed)
+        .trim();
+    if inner.is_empty() {
+        None
+    } else {
+        Some(inner.to_string())
+    }
 }
 
 /// Where the ingest lockfile for a given database lives: right next to it.
@@ -232,6 +306,10 @@ pub async fn finish_run(
 pub struct SeenMail {
     pub message_id: String,
     pub sender: String,
+    /// The message's RFC 5322 Message-ID, already normalized via
+    /// [`normalize_rfc_message_id`]. None when the message has none — such
+    /// messages keep the pre-Phase-D behavior (counted, NULL column).
+    pub rfc_message_id: Option<String>,
 }
 
 /// Everything that flows over the writer channel; all durable writes ride
@@ -266,7 +344,11 @@ pub enum WriteMsg {
 /// The insert-and-count pair is idempotent per message id: the sender counter
 /// (and the run's messages_new) is only incremented when the INSERT OR IGNORE
 /// actually inserts the row, so a message that slips through a read-side seen
-/// check twice is still counted exactly once. Between messages the writer
+/// check twice is still counted exactly once. Cross-source dedupe happens in
+/// the same transaction: a newly inserted row whose normalized Message-ID
+/// already exists on any other seen_mails row (the other keyspace having
+/// ingested the same message) is recorded as seen but not counted — neither
+/// the sender nor the run's messages_new moves. Between messages the writer
 /// heartbeats the run row (~2s) so watchers can distinguish "slow" from
 /// "stalled".
 pub async fn db_writer(
@@ -282,17 +364,25 @@ pub async fn db_writer(
                 None => break,
                 Some(WriteMsg::Seen(mail)) => {
                     let mut tx = conn.begin().await?;
-                    let newly_seen = mark_seen(&mail.message_id, &mut *tx).await?;
+                    let newly_seen = mark_seen(&mail, &mut *tx).await?;
                     if newly_seen {
-                        increment_sender_mails(&mail.sender, &mut tx).await?;
-                        sqlx::query(
-                            "UPDATE ingest_runs SET messages_new = messages_new + 1, \
-                             updated_at_unix = ? WHERE run_id = ?",
-                        )
-                        .bind(now_unix())
-                        .bind(run_id)
-                        .execute(&mut *tx)
-                        .await?;
+                        let cross_source_dup = match mail.rfc_message_id.as_deref() {
+                            Some(rfc_id) => {
+                                rfc_id_exists_elsewhere(rfc_id, &mail.message_id, &mut *tx).await?
+                            }
+                            None => false,
+                        };
+                        if !cross_source_dup {
+                            increment_sender_mails(&mail.sender, &mut tx).await?;
+                            sqlx::query(
+                                "UPDATE ingest_runs SET messages_new = messages_new + 1, \
+                                 updated_at_unix = ? WHERE run_id = ?",
+                            )
+                            .bind(now_unix())
+                            .bind(run_id)
+                            .execute(&mut *tx)
+                            .await?;
+                        }
                     }
                     tx.commit().await?;
                 }
@@ -354,14 +444,36 @@ pub async fn seen_mail(
     Ok(false)
 }
 
-/// Record a message id as seen. Returns whether the id was newly inserted;
-/// false means it was already present and must not be counted again.
-async fn mark_seen(message_id: &str, executor: impl SqliteExecutor<'_>) -> anyhow::Result<bool> {
-    let result = sqlx::query("INSERT OR IGNORE INTO seen_mails (mail_id) VALUES (?)")
-        .bind(message_id)
-        .execute(executor)
-        .await?;
+/// Record a message id as seen (with its normalized Message-ID when known).
+/// Returns whether the id was newly inserted; false means it was already
+/// present and must not be counted again.
+async fn mark_seen(mail: &SeenMail, executor: impl SqliteExecutor<'_>) -> anyhow::Result<bool> {
+    let result =
+        sqlx::query("INSERT OR IGNORE INTO seen_mails (mail_id, rfc_message_id) VALUES (?, ?)")
+            .bind(&mail.message_id)
+            .bind(&mail.rfc_message_id)
+            .execute(executor)
+            .await?;
     Ok(result.rows_affected() > 0)
+}
+
+/// Whether a normalized Message-ID is already recorded on any seen_mails row
+/// other than `own_mail_id`. This is the cross-source duplicate check, run in
+/// both directions: a scan finding an mbox-imported message and an import
+/// finding a scanned one both land here.
+async fn rfc_id_exists_elsewhere(
+    rfc_id: &str,
+    own_mail_id: &str,
+    executor: impl SqliteExecutor<'_>,
+) -> anyhow::Result<bool> {
+    let exists: i64 = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM seen_mails WHERE rfc_message_id = ? AND mail_id <> ?)",
+    )
+    .bind(rfc_id)
+    .bind(own_mail_id)
+    .fetch_one(executor)
+    .await?;
+    Ok(exists != 0)
 }
 
 async fn increment_sender_mails(
@@ -399,6 +511,157 @@ async fn increment_sender_mails(
         .execute(&mut **tx)
         .await?;
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `scan --backfill-message-ids`: populate rfc_message_id on historical API
+// scan rows and collapse the cross-source double counts that accumulated
+// while sources were mixed without it.
+// ---------------------------------------------------------------------------
+
+/// One backfilled scan row, produced by the metadata fetch loop and sent to
+/// the single backfill writer task.
+pub struct BackfillMsg {
+    /// The bare Gmail id of the seen_mails row being repaired.
+    pub mail_id: String,
+    /// The fetched message's Message-ID, already normalized via
+    /// [`normalize_rfc_message_id`]; None when the message has none.
+    pub rfc_message_id: Option<String>,
+    /// The sender extracted from the fetched message, cleaned exactly like
+    /// the scan does — this is whose count is decremented when the row turns
+    /// out to be a cross-source duplicate.
+    pub sender: String,
+}
+
+/// What the backfill writer did, for the run summary.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BackfillOutcome {
+    /// Rows received from the fetch loop.
+    pub examined: u64,
+    /// Rows whose rfc_message_id was populated with a real Message-ID.
+    pub populated: u64,
+    /// Rows fetched but found to have no Message-ID header; marked with the
+    /// empty-string sentinel so a re-run does not fetch them again.
+    pub missing_id: u64,
+    /// Duplicate pairs collapsed: sender counts decremented once each.
+    pub decremented: u64,
+    /// Rows that were already repaired when their result arrived (replays);
+    /// always 0 in a single clean run.
+    pub already_done: u64,
+}
+
+/// The single DB writer for a backfill run: applies each fetched row in its
+/// own transaction and heartbeats the run row like [`db_writer`]. Returns a
+/// summary of what it changed.
+///
+/// Per-row logic (the collapse fused with the populate, so partial completion
+/// plus a re-run is always exact):
+/// - a row that is no longer NULL is skipped — populate-and-decrement already
+///   happened, replaying the message is a no-op;
+/// - otherwise the fetched Message-ID (or the '' sentinel for "fetched, has
+///   none") is stored, and if the normalized id already exists on any *other*
+///   row — the mbox side of a historical double count, or an earlier repaired
+///   scan row with the same Message-ID — the sender's count is decremented
+///   once, never below zero.
+///
+/// Because the decision is committed atomically with the populate, a run
+/// killed anywhere leaves every row either fully repaired (populated and, if
+/// it was a duplicate, decremented) or untouched (still NULL, picked up by
+/// the next run). A second run over a repaired database finds no NULL rows
+/// and does nothing.
+pub async fn backfill_writer(
+    mut conn: SqliteConnection,
+    mut rx: mpsc::Receiver<BackfillMsg>,
+    run_id: i64,
+) -> anyhow::Result<BackfillOutcome> {
+    let mut outcome = BackfillOutcome::default();
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(2));
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            msg = rx.recv() => match msg {
+                None => break,
+                Some(msg) => {
+                    let mut tx = conn.begin().await?;
+                    apply_backfill(&mut tx, &msg, &mut outcome).await?;
+                    sqlx::query(
+                        "UPDATE ingest_runs SET messages_seen = ?, messages_new = ?, \
+                         updated_at_unix = ? WHERE run_id = ?",
+                    )
+                    .bind(outcome.examined as i64)
+                    .bind((outcome.populated + outcome.missing_id) as i64)
+                    .bind(now_unix())
+                    .bind(run_id)
+                    .execute(&mut *tx)
+                    .await?;
+                    tx.commit().await?;
+                }
+            },
+            _ = heartbeat.tick() => {
+                sqlx::query("UPDATE ingest_runs SET updated_at_unix = ? WHERE run_id = ?")
+                    .bind(now_unix())
+                    .bind(run_id)
+                    .execute(&mut conn)
+                    .await?;
+            }
+        }
+    }
+    Ok(outcome)
+}
+
+async fn apply_backfill(
+    tx: &mut Transaction<'_, Sqlite>,
+    msg: &BackfillMsg,
+    outcome: &mut BackfillOutcome,
+) -> anyhow::Result<()> {
+    outcome.examined += 1;
+    let still_null: i64 = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM seen_mails \
+         WHERE mail_id = ? AND rfc_message_id IS NULL)",
+    )
+    .bind(&msg.mail_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    if still_null == 0 {
+        outcome.already_done += 1;
+        return Ok(());
+    }
+    match msg.rfc_message_id.as_deref() {
+        None => {
+            // '' sentinel: fetched, genuinely has no Message-ID. Never
+            // matched by the dedupe check (which only binds non-empty
+            // normalized ids), but no longer NULL, so re-runs skip it.
+            sqlx::query("UPDATE seen_mails SET rfc_message_id = '' WHERE mail_id = ?")
+                .bind(&msg.mail_id)
+                .execute(&mut **tx)
+                .await?;
+            outcome.missing_id += 1;
+        }
+        Some(rfc_id) => {
+            let duplicate = rfc_id_exists_elsewhere(rfc_id, &msg.mail_id, &mut **tx).await?;
+            sqlx::query("UPDATE seen_mails SET rfc_message_id = ? WHERE mail_id = ?")
+                .bind(rfc_id)
+                .bind(&msg.mail_id)
+                .execute(&mut **tx)
+                .await?;
+            outcome.populated += 1;
+            if duplicate {
+                // This message was counted once by the scan (this row) and
+                // once by the other row's ingester: collapse exactly one of
+                // the two, clamped at zero in case the counts were already
+                // edited out from under us.
+                sqlx::query(
+                    "UPDATE senders SET mails_sent = mails_sent - 1 \
+                     WHERE sender = ? AND mails_sent > 0",
+                )
+                .bind(&msg.sender)
+                .execute(&mut **tx)
+                .await?;
+                outcome.decremented += 1;
+            }
+        }
+    }
     Ok(())
 }
 
@@ -489,6 +752,26 @@ mod tests {
             .unwrap()
     }
 
+    async fn index_exists(conn: &mut SqliteConnection, name: &str) -> bool {
+        let count: i64 =
+            sqlx::query("SELECT count(1) AS ct FROM sqlite_master WHERE type='index' AND name=?")
+                .bind(name)
+                .fetch_one(conn)
+                .await
+                .unwrap()
+                .try_get("ct")
+                .unwrap();
+        count > 0
+    }
+
+    async fn rfc_of(conn: &mut SqliteConnection, mail_id: &str) -> Option<String> {
+        sqlx::query_scalar("SELECT rfc_message_id FROM seen_mails WHERE mail_id = ?")
+            .bind(mail_id)
+            .fetch_one(conn)
+            .await
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn migrate_initializes_a_fresh_database() {
         let mut conn = memory_conn().await;
@@ -496,7 +779,13 @@ mod tests {
         assert!(table_exists(&mut conn, "seen_mails").await);
         assert!(table_exists(&mut conn, "senders").await);
         assert!(table_exists(&mut conn, "ingest_runs").await);
+        assert!(index_exists(&mut conn, "seen_mails_rfc_message_id").await);
         assert_eq!(user_version(&mut conn).await, SCHEMA_VERSION);
+        // The column is usable on a fresh database.
+        sqlx::query("INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES ('g1', 'a@b')")
+            .execute(&mut conn)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -524,9 +813,11 @@ mod tests {
 
         migrate(&mut conn).await.unwrap();
 
-        assert_eq!(user_version(&mut conn).await, 1);
+        assert_eq!(user_version(&mut conn).await, SCHEMA_VERSION);
         assert!(table_exists(&mut conn, "ingest_runs").await);
-        // Existing data survives; pre-index duplicates are collapsed.
+        assert!(index_exists(&mut conn, "seen_mails_rfc_message_id").await);
+        // Existing data survives; pre-index duplicates are collapsed; the
+        // new column defaults to NULL ("Message-ID not known yet").
         let seen: i64 = sqlx::query("SELECT count(1) AS ct FROM seen_mails")
             .fetch_one(&mut conn)
             .await
@@ -534,6 +825,7 @@ mod tests {
             .try_get("ct")
             .unwrap();
         assert_eq!(seen, 2);
+        assert_eq!(rfc_of(&mut conn, "m1").await, None);
         let mails: i64 = sqlx::query("SELECT mails_sent FROM senders WHERE sender='a@example.com'")
             .fetch_one(&mut conn)
             .await
@@ -544,7 +836,100 @@ mod tests {
 
         // Running again is a no-op.
         migrate(&mut conn).await.unwrap();
-        assert_eq!(user_version(&mut conn).await, 1);
+        assert_eq!(user_version(&mut conn).await, SCHEMA_VERSION);
+    }
+
+    /// A version-1 database (Phases A-C): migration 2 adds the column and
+    /// index, and populates `mid:` rows from the Message-ID embedded in their
+    /// key — only bare Gmail rows are left NULL for the API backfill.
+    #[tokio::test]
+    async fn migrate_upgrades_a_version_1_database_and_populates_mid_rows() {
+        let mut conn = memory_conn().await;
+        migrate(&mut conn).await.unwrap();
+        // Rewind to version 1: drop the Phase-D column by rebuilding the
+        // table the way a v1 binary left it.
+        sqlx::query("DROP TABLE seen_mails")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE seen_mails (mail_id string)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        sqlx::query("CREATE UNIQUE INDEX seen_mails_mail_id_unique ON seen_mails (mail_id)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO seen_mails (mail_id) VALUES \
+             ('gmailid1'), ('mid:<m1@example.com>'), ('mid: <m2@example.com> '), ('mid:')",
+        )
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        sqlx::query("PRAGMA user_version = 1")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+
+        migrate(&mut conn).await.unwrap();
+
+        assert_eq!(user_version(&mut conn).await, SCHEMA_VERSION);
+        assert!(index_exists(&mut conn, "seen_mails_rfc_message_id").await);
+        // Scan rows stay NULL (repaired later by the backfill)...
+        assert_eq!(rfc_of(&mut conn, "gmailid1").await, None);
+        // ...mid: rows are populated with the shared normalization...
+        assert_eq!(
+            rfc_of(&mut conn, "mid:<m1@example.com>").await.as_deref(),
+            Some("m1@example.com")
+        );
+        assert_eq!(
+            rfc_of(&mut conn, "mid: <m2@example.com> ").await.as_deref(),
+            Some("m2@example.com")
+        );
+        // ...and a degenerate empty embedded id gets the '' marker, not NULL.
+        assert_eq!(rfc_of(&mut conn, "mid:").await.as_deref(), Some(""));
+
+        // Running again is a no-op.
+        migrate(&mut conn).await.unwrap();
+        assert_eq!(user_version(&mut conn).await, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn normalize_rfc_message_id_variants() {
+        for raw in [
+            "<id@host>",
+            "id@host",
+            "  <id@host>  ",
+            "\t<id@host>\r\n",
+            "< id@host >",
+            "  id@host  ",
+        ] {
+            assert_eq!(
+                normalize_rfc_message_id(raw).as_deref(),
+                Some("id@host"),
+                "failed for {raw:?}"
+            );
+        }
+        // Case is preserved.
+        assert_eq!(
+            normalize_rfc_message_id("<ID@Host>").as_deref(),
+            Some("ID@Host")
+        );
+        // Only one enclosing pair is stripped, and unbalanced brackets stay.
+        assert_eq!(
+            normalize_rfc_message_id("<<id@host>>").as_deref(),
+            Some("<id@host>")
+        );
+        assert_eq!(
+            normalize_rfc_message_id("<id@host").as_deref(),
+            Some("<id@host")
+        );
+        // Nothing usable.
+        assert_eq!(normalize_rfc_message_id(""), None);
+        assert_eq!(normalize_rfc_message_id("   "), None);
+        assert_eq!(normalize_rfc_message_id("<>"), None);
+        assert_eq!(normalize_rfc_message_id(" < > "), None);
     }
 
     #[tokio::test]
@@ -638,6 +1023,7 @@ mod tests {
             tx.send(WriteMsg::Seen(SeenMail {
                 message_id: "mid:<m1@example.com>".into(),
                 sender: "a@example.com".into(),
+                rfc_message_id: Some("m1@example.com".into()),
             }))
             .await
             .unwrap();
@@ -645,6 +1031,7 @@ mod tests {
         tx.send(WriteMsg::Seen(SeenMail {
             message_id: "mid:<m2@example.com>".into(),
             sender: "a@example.com".into(),
+            rfc_message_id: Some("m2@example.com".into()),
         }))
         .await
         .unwrap();
@@ -712,6 +1099,367 @@ mod tests {
             .unwrap();
         assert_eq!(row.try_get::<String, _>("state").unwrap(), "running");
         assert_eq!(row.try_get::<Option<String>, _>("auth_url").unwrap(), None);
+    }
+
+    // --- cross-source dedupe (Phase D) -------------------------------------
+
+    async fn sender_count(conn: &mut SqliteConnection, sender: &str) -> Option<i64> {
+        sqlx::query_scalar("SELECT mails_sent FROM senders WHERE sender = ?")
+            .bind(sender)
+            .fetch_optional(conn)
+            .await
+            .unwrap()
+    }
+
+    async fn seen_count(conn: &mut SqliteConnection) -> i64 {
+        sqlx::query_scalar("SELECT count(1) FROM seen_mails")
+            .fetch_one(conn)
+            .await
+            .unwrap()
+    }
+
+    fn seen(message_id: &str, sender: &str, rfc: Option<&str>) -> WriteMsg {
+        WriteMsg::Seen(SeenMail {
+            message_id: message_id.into(),
+            sender: sender.into(),
+            rfc_message_id: rfc.map(str::to_string),
+        })
+    }
+
+    /// Run one batch of writer messages as its own ingest run (fresh writer
+    /// task, like a separate scan/import invocation) and return messages_new.
+    async fn run_writer_batch(
+        options: &SqliteConnectOptions,
+        source: &str,
+        msgs: Vec<WriteMsg>,
+    ) -> i64 {
+        let mut conn = SqliteConnection::connect_with(options).await.unwrap();
+        let run_id = create_run(&mut conn, source, None).await.unwrap();
+        let (tx, rx) = mpsc::channel(64);
+        let writer = tokio::spawn(db_writer(conn, rx, run_id));
+        for msg in msgs {
+            tx.send(msg).await.unwrap();
+        }
+        drop(tx);
+        writer.await.unwrap().unwrap();
+        let mut conn = SqliteConnection::connect_with(options).await.unwrap();
+        sqlx::query_scalar("SELECT messages_new FROM ingest_runs WHERE run_id = ?")
+            .bind(run_id)
+            .fetch_one(&mut conn)
+            .await
+            .unwrap()
+    }
+
+    /// Scan first, then import an overlapping mailbox: the shared message is
+    /// marked seen by both keyspaces but counted once — sender totals equal
+    /// the true union. Messages without a Message-ID keep current behavior.
+    #[tokio::test]
+    async fn forward_dedupe_scan_then_import() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = file_options(&dir.path().join("stats.db"));
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        migrate(&mut conn).await.unwrap();
+        drop(conn);
+
+        // Scan: two messages from Alice (one with no Message-ID), one from Bob.
+        let new = run_writer_batch(
+            &options,
+            "gmail_api",
+            vec![
+                seen("g1", "a@example.com", Some("m1@example.com")),
+                seen("g2", "a@example.com", None),
+                seen("g3", "b@example.com", Some("m3@example.com")),
+            ],
+        )
+        .await;
+        assert_eq!(new, 3);
+
+        // Import: overlaps on m1 (dup, not counted) and adds m4 (counted).
+        // The importer never emits Seen for id-less messages, so no None here.
+        let new = run_writer_batch(
+            &options,
+            "mbox",
+            vec![
+                seen(
+                    "mid:<m1@example.com>",
+                    "a@example.com",
+                    Some("m1@example.com"),
+                ),
+                seen(
+                    "mid:<m4@example.com>",
+                    "c@example.com",
+                    Some("m4@example.com"),
+                ),
+            ],
+        )
+        .await;
+        assert_eq!(new, 1, "the overlapping message must be seen-not-new");
+
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        assert_eq!(sender_count(&mut conn, "a@example.com").await, Some(2));
+        assert_eq!(sender_count(&mut conn, "b@example.com").await, Some(1));
+        assert_eq!(sender_count(&mut conn, "c@example.com").await, Some(1));
+        // Idempotency intact: the duplicate's seen row exists in both keyspaces.
+        assert_eq!(seen_count(&mut conn).await, 5);
+
+        // Replaying the import adds nothing.
+        let new = run_writer_batch(
+            &options,
+            "mbox",
+            vec![seen(
+                "mid:<m1@example.com>",
+                "a@example.com",
+                Some("m1@example.com"),
+            )],
+        )
+        .await;
+        assert_eq!(new, 0);
+        assert_eq!(sender_count(&mut conn, "a@example.com").await, Some(2));
+    }
+
+    /// The other direction: import first, then scan the same mailbox.
+    #[tokio::test]
+    async fn forward_dedupe_import_then_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = file_options(&dir.path().join("stats.db"));
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        migrate(&mut conn).await.unwrap();
+        drop(conn);
+
+        let new = run_writer_batch(
+            &options,
+            "mbox",
+            vec![
+                seen(
+                    "mid:<m1@example.com>",
+                    "a@example.com",
+                    Some("m1@example.com"),
+                ),
+                seen(
+                    "mid:<m2@example.com>",
+                    "b@example.com",
+                    Some("m2@example.com"),
+                ),
+            ],
+        )
+        .await;
+        assert_eq!(new, 2);
+
+        // Scan sees the same two messages plus one new id-less one.
+        let new = run_writer_batch(
+            &options,
+            "gmail_api",
+            vec![
+                seen("g1", "a@example.com", Some("m1@example.com")),
+                seen("g2", "b@example.com", Some("m2@example.com")),
+                seen("g3", "b@example.com", None),
+            ],
+        )
+        .await;
+        assert_eq!(new, 1, "only the id-less message is new");
+
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        assert_eq!(sender_count(&mut conn, "a@example.com").await, Some(1));
+        assert_eq!(sender_count(&mut conn, "b@example.com").await, Some(2));
+        assert_eq!(seen_count(&mut conn).await, 5);
+    }
+
+    /// Fixture for backfill tests: a database that historically mixed sources
+    /// without rfc_message_id. Scan rows g1/g2 (NULL rfc) and mbox rows for
+    /// m1/m2, with senders double-counted accordingly.
+    async fn double_counted_fixture(options: &SqliteConnectOptions) {
+        let mut conn = SqliteConnection::connect_with(options).await.unwrap();
+        migrate(&mut conn).await.unwrap();
+        sqlx::query(
+            "INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES \
+             ('g1', NULL), \
+             ('g2', NULL), \
+             ('g3', NULL), \
+             ('mid:<m1@example.com>', 'm1@example.com'), \
+             ('mid:<m2@example.com>', 'm2@example.com')",
+        )
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        // Alice sent m1 (counted by scan AND import = 2) plus the id-less g3
+        // (counted once): recorded 3, true count 2. Bob sent m2 (counted
+        // twice): recorded 2, true count 1.
+        sqlx::query(
+            "INSERT INTO senders (sender, mails_sent) VALUES \
+             ('a@example.com', 3), ('b@example.com', 2)",
+        )
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    fn backfill(mail_id: &str, rfc: Option<&str>, sender: &str) -> BackfillMsg {
+        BackfillMsg {
+            mail_id: mail_id.into(),
+            rfc_message_id: rfc.map(str::to_string),
+            sender: sender.into(),
+        }
+    }
+
+    async fn run_backfill_batch(
+        options: &SqliteConnectOptions,
+        msgs: Vec<BackfillMsg>,
+    ) -> BackfillOutcome {
+        let mut conn = SqliteConnection::connect_with(options).await.unwrap();
+        let run_id = create_run(&mut conn, "backfill", None).await.unwrap();
+        let (tx, rx) = mpsc::channel(64);
+        let writer = tokio::spawn(backfill_writer(conn, rx, run_id));
+        for msg in msgs {
+            tx.send(msg).await.unwrap();
+        }
+        drop(tx);
+        writer.await.unwrap().unwrap()
+    }
+
+    /// The repair pass: populates scan rows, collapses each historical
+    /// double count exactly once, marks id-less rows with the '' sentinel,
+    /// and a second run finds nothing to do.
+    #[tokio::test]
+    async fn backfill_collapses_historical_double_counts_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = file_options(&dir.path().join("stats.db"));
+        double_counted_fixture(&options).await;
+
+        let outcome = run_backfill_batch(
+            &options,
+            vec![
+                backfill("g1", Some("m1@example.com"), "a@example.com"),
+                backfill("g2", Some("m2@example.com"), "b@example.com"),
+                backfill("g3", None, "a@example.com"),
+            ],
+        )
+        .await;
+        assert_eq!(
+            outcome,
+            BackfillOutcome {
+                examined: 3,
+                populated: 2,
+                missing_id: 1,
+                decremented: 2,
+                already_done: 0,
+            }
+        );
+
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        assert_eq!(sender_count(&mut conn, "a@example.com").await, Some(2));
+        assert_eq!(sender_count(&mut conn, "b@example.com").await, Some(1));
+        assert_eq!(
+            rfc_of(&mut conn, "g1").await.as_deref(),
+            Some("m1@example.com")
+        );
+        assert_eq!(
+            rfc_of(&mut conn, "g2").await.as_deref(),
+            Some("m2@example.com")
+        );
+        assert_eq!(rfc_of(&mut conn, "g3").await.as_deref(), Some(""));
+        // Nothing is left for a second run to fetch.
+        let pending: i64 = sqlx::query_scalar(
+            "SELECT count(1) FROM seen_mails \
+             WHERE rfc_message_id IS NULL AND mail_id NOT LIKE 'mid:%'",
+        )
+        .fetch_one(&mut conn)
+        .await
+        .unwrap();
+        assert_eq!(pending, 0);
+
+        // Replaying the very same results (a crashed run's retry) is a no-op:
+        // every row is already repaired, no count moves again.
+        let outcome = run_backfill_batch(
+            &options,
+            vec![
+                backfill("g1", Some("m1@example.com"), "a@example.com"),
+                backfill("g2", Some("m2@example.com"), "b@example.com"),
+                backfill("g3", None, "a@example.com"),
+            ],
+        )
+        .await;
+        assert_eq!(outcome.already_done, 3);
+        assert_eq!(outcome.decremented, 0);
+        assert_eq!(sender_count(&mut conn, "a@example.com").await, Some(2));
+        assert_eq!(sender_count(&mut conn, "b@example.com").await, Some(1));
+    }
+
+    /// A run that dies mid-collapse leaves every processed row fully repaired
+    /// and every unprocessed row untouched; the resumed run repairs exactly
+    /// the remainder.
+    #[tokio::test]
+    async fn backfill_interrupted_midway_resumes_exactly() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = file_options(&dir.path().join("stats.db"));
+        double_counted_fixture(&options).await;
+
+        // First run only got through g1 before dying.
+        let outcome = run_backfill_batch(
+            &options,
+            vec![backfill("g1", Some("m1@example.com"), "a@example.com")],
+        )
+        .await;
+        assert_eq!(outcome.decremented, 1);
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        assert_eq!(sender_count(&mut conn, "a@example.com").await, Some(2));
+        assert_eq!(sender_count(&mut conn, "b@example.com").await, Some(2));
+        assert_eq!(rfc_of(&mut conn, "g2").await, None);
+
+        // The next run's NULL-row query finds exactly the remainder.
+        let pending: Vec<String> = sqlx::query_scalar(
+            "SELECT mail_id FROM seen_mails \
+             WHERE rfc_message_id IS NULL AND mail_id NOT LIKE 'mid:%' ORDER BY mail_id",
+        )
+        .fetch_all(&mut conn)
+        .await
+        .unwrap();
+        assert_eq!(pending, vec!["g2".to_string(), "g3".to_string()]);
+
+        let outcome = run_backfill_batch(
+            &options,
+            vec![
+                backfill("g2", Some("m2@example.com"), "b@example.com"),
+                backfill("g3", None, "a@example.com"),
+            ],
+        )
+        .await;
+        assert_eq!(outcome.decremented, 1);
+        assert_eq!(sender_count(&mut conn, "a@example.com").await, Some(2));
+        assert_eq!(sender_count(&mut conn, "b@example.com").await, Some(1));
+    }
+
+    /// The decrement clamps at zero even when counts were edited externally.
+    #[tokio::test]
+    async fn backfill_never_decrements_below_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = file_options(&dir.path().join("stats.db"));
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        migrate(&mut conn).await.unwrap();
+        sqlx::query(
+            "INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES \
+             ('g1', NULL), ('mid:<m1@example.com>', 'm1@example.com')",
+        )
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO senders (sender, mails_sent) VALUES ('a@example.com', 0)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        drop(conn);
+
+        let outcome = run_backfill_batch(
+            &options,
+            vec![backfill("g1", Some("m1@example.com"), "a@example.com")],
+        )
+        .await;
+        assert_eq!(outcome.decremented, 1);
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        assert_eq!(
+            sender_count(&mut conn, "a@example.com").await,
+            Some(0),
+            "count must never go below zero"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,11 @@ gmail_stats - collect per-sender mail counts into a local SQLite database
 USAGE:
     gmail_stats [scan] [OPTIONS]           scan Gmail over the API (OAuth; the default)
     gmail_stats import <PATH> [OPTIONS]    import a Google Takeout mbox export
+    gmail_stats scan --backfill-message-ids [OPTIONS]
+                                           repair pass: fetch the Message-ID header for
+                                           previously scanned messages and collapse
+                                           cross-source duplicate counts (idempotent;
+                                           re-run any time to continue an interrupted pass)
 
 OPTIONS:
     --db <PATH>            SQLite database path
@@ -91,8 +96,18 @@ fn chatty() -> bool {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Mode {
-    Scan { resume: Option<i64> },
-    Import { path: PathBuf, resume: Option<i64> },
+    Scan {
+        resume: Option<i64>,
+    },
+    Import {
+        path: PathBuf,
+        resume: Option<i64>,
+    },
+    /// `scan --backfill-message-ids`: an ingest run that repairs historical
+    /// scan rows (fetch Message-ID headers, collapse cross-source duplicate
+    /// counts). Naturally resumable: re-running continues with whatever rows
+    /// are still unrepaired, so it takes no --resume run id.
+    BackfillMessageIds,
 }
 
 #[derive(Debug)]
@@ -120,6 +135,7 @@ fn parse_args(
     let mut quiet = false;
     let mut verbose = false;
     let mut resume = None;
+    let mut backfill = false;
     let mut positionals: Vec<String> = Vec::new();
 
     let mut it = args.into_iter();
@@ -145,6 +161,7 @@ fn parse_args(
                         .map_err(|_| format!("--resume expects a run id, got {v:?}"))?,
                 );
             }
+            "--backfill-message-ids" => backfill = true,
             "--quiet" => quiet = true,
             "--verbose" => verbose = true,
             "-h" | "--help" => return Ok(ParsedArgs::Help),
@@ -162,9 +179,21 @@ fn parse_args(
             if positionals.len() > 1 {
                 return Err(format!("unexpected argument {:?}", positionals[1]));
             }
-            Mode::Scan { resume }
+            if backfill {
+                if resume.is_some() {
+                    return Err("--backfill-message-ids takes no --resume: re-running it \
+                         automatically continues with the still-unrepaired rows"
+                        .to_string());
+                }
+                Mode::BackfillMessageIds
+            } else {
+                Mode::Scan { resume }
+            }
         }
         Some("import") => {
+            if backfill {
+                return Err("--backfill-message-ids only applies to scan".to_string());
+            }
             let path = positionals
                 .get(1)
                 .ok_or_else(|| "import requires the path to an mbox file".to_string())?;
@@ -290,6 +319,7 @@ async fn main() -> anyhow::Result<()> {
             report_import_summary(&summary, path);
             Ok(())
         }
+        Mode::BackfillMessageIds => run_backfill(&cfg, &options, writer_conn, cancel).await,
     }
 }
 
@@ -556,9 +586,12 @@ fn parse_and_send(
                 // RFC Message-IDs live in the `mid:` namespace of seen_mails so
                 // they can never collide with Gmail API ids, and re-imports
                 // stay idempotent. This namespacing is the permanent keyspace
-                // rule for cross-source dedupe (issue #26).
+                // rule for cross-source dedupe (issue #26); the normalized id
+                // additionally lands in rfc_message_id, where the writer's
+                // check-before-increment dedupes against scanned rows.
                 write_tx
                     .blocking_send(WriteMsg::Seen(SeenMail {
+                        rfc_message_id: ingest::normalize_rfc_message_id(&mid),
                         message_id: format!("mid:{mid}"),
                         sender,
                     }))
@@ -1284,7 +1317,11 @@ async fn parse_messages(ctx: &ScanCtx<'_>, messages: Vec<Message>) -> anyhow::Re
                 }
 
                 write_tx
-                    .send(WriteMsg::Seen(SeenMail { message_id, sender }))
+                    .send(WriteMsg::Seen(SeenMail {
+                        rfc_message_id: get_rfc_message_id(&message),
+                        message_id,
+                        sender,
+                    }))
                     .await
                     .map_err(|_| anyhow::anyhow!("DB writer task closed unexpectedly"))?;
 
@@ -1302,17 +1339,43 @@ async fn fetch_message(
     message_id: &str,
     rate_limiter: &Mutex<Interval>,
 ) -> anyhow::Result<Message> {
+    fetch_message_with(hub, message_id, rate_limiter, None).await
+}
+
+/// The backfill's variant of [`fetch_message`]: same rate limiting and retry
+/// treatment, but format=metadata restricted to the named headers — much
+/// cheaper than a full fetch when only Message-ID and From are needed.
+async fn fetch_message_metadata_headers(
+    hub: &GmailHub,
+    message_id: &str,
+    rate_limiter: &Mutex<Interval>,
+    headers: &[&str],
+) -> anyhow::Result<Message> {
+    fetch_message_with(hub, message_id, rate_limiter, Some(headers)).await
+}
+
+async fn fetch_message_with(
+    hub: &GmailHub,
+    message_id: &str,
+    rate_limiter: &Mutex<Interval>,
+    metadata_headers: Option<&[&str]>,
+) -> anyhow::Result<Message> {
     let mut attempts = 0;
     let mut backoff = Duration::from_secs(1);
     loop {
         rate_limiter.lock().await.tick().await;
 
-        let res = hub
+        let mut call = hub
             .users()
             .messages_get("me", message_id)
-            .add_scope(Scope::Readonly)
-            .doit()
-            .await;
+            .add_scope(Scope::Readonly);
+        if let Some(headers) = metadata_headers {
+            call = call.format("metadata");
+            for header in headers {
+                call = call.add_metadata_headers(header);
+            }
+        }
+        let res = call.doit().await;
 
         match res {
             Ok((_, message)) => return Ok(message),
@@ -1448,6 +1511,327 @@ fn classify_scan_error(err: &anyhow::Error) -> &'static str {
 }
 
 // ---------------------------------------------------------------------------
+// scan --backfill-message-ids: repair pass for historical scan rows
+// ---------------------------------------------------------------------------
+
+/// Headers requested by the backfill's metadata fetch: the Message-ID being
+/// backfilled, plus the sender headers so a collapsed duplicate knows whose
+/// count to decrement (same priority as the scan: From, then Return-Path).
+const BACKFILL_METADATA_HEADERS: &[&str] = &["Message-ID", "From", "Return-Path"];
+
+// Rows the backfill still has to repair are matched by the predicate
+// `rfc_message_id IS NULL AND mail_id NOT LIKE 'mid:%'`: API-scan rows (bare
+// Gmail ids, never `mid:`-prefixed) whose Message-ID is not known yet.
+// Repaired rows are non-NULL (a real id, or '' for "fetched, has none"), so
+// the same predicate makes re-runs and resumption automatic. It appears
+// inline in the two queries below (sqlx requires literal SQL).
+
+/// The repair pass behind `scan --backfill-message-ids` (issue #26 Phase D):
+/// a first-class ingest run — flock and stale-run cleanup happen in main()
+/// like every run, it writes an ingest_runs row with heartbeats, stops
+/// cleanly on SIGTERM/SIGINT, and is idempotent/resumable by construction.
+///
+/// It fetches format=metadata for every unrepaired scan row through the same
+/// rate-limited, retrying fetch machinery as the scan, records the normalized
+/// Message-ID, and collapses historical cross-source double counts (see
+/// ingest::backfill_writer for the per-row transaction).
+async fn run_backfill(
+    cfg: &Config,
+    options: &SqliteConnectOptions,
+    mut writer_conn: SqliteConnection,
+    cancel: Arc<AtomicBool>,
+) -> anyhow::Result<()> {
+    let fetch_concurrency: usize =
+        env_or("GMAIL_STATS_FETCH_CONCURRENCY", DEFAULT_FETCH_CONCURRENCY)?;
+    anyhow::ensure!(
+        fetch_concurrency >= 1,
+        "GMAIL_STATS_FETCH_CONCURRENCY must be at least 1"
+    );
+    let rate_limit_ms: u64 = env_or("GMAIL_STATS_RATE_LIMIT_MS", DEFAULT_RATE_LIMIT_MS)?;
+    anyhow::ensure!(
+        rate_limit_ms >= 1,
+        "GMAIL_STATS_RATE_LIMIT_MS must be at least 1"
+    );
+
+    // Everything still to do; also the run's total for progress display. A
+    // fully repaired database finishes here without touching the network.
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT count(1) FROM seen_mails \
+         WHERE rfc_message_id IS NULL AND mail_id NOT LIKE 'mid:%'",
+    )
+    .fetch_one(&mut writer_conn)
+    .await?;
+    let run_id = ingest::create_run(&mut writer_conn, "backfill", None).await?;
+    // The writer task isn't spawned yet, so this connection is still the
+    // single writer; set the total directly.
+    sqlx::query("UPDATE ingest_runs SET total_estimate = ? WHERE run_id = ?")
+        .bind(pending)
+        .bind(run_id)
+        .execute(&mut writer_conn)
+        .await?;
+    if pending == 0 {
+        drop(writer_conn);
+        ingest::finish_run(options, run_id, "done", None, None).await?;
+        if chatty() {
+            println!(
+                "nothing to backfill: every scanned message already has its \
+                 Message-ID recorded"
+            );
+        }
+        return Ok(());
+    }
+    if chatty() {
+        println!("backfilling Message-IDs for {pending} scanned message(s) (run {run_id})");
+    }
+
+    // OAuth, exactly like the scan (same credential/token files). Consent is
+    // terminal-only here: the backfill is started from a shell, and a repaired
+    // token cache from the original scan normally makes this silent.
+    let secret = match yup_oauth2::read_application_secret(&cfg.credentials).await {
+        Ok(secret) => secret,
+        Err(e) => {
+            drop(writer_conn);
+            let msg = format!(
+                "reading OAuth client secret from {}: {e}",
+                cfg.credentials.display()
+            );
+            ingest::finish_run(
+                options,
+                run_id,
+                "failed",
+                Some("missing_credentials"),
+                Some(&msg),
+            )
+            .await
+            .ok();
+            return Err(anyhow::Error::new(e).context(format!(
+                "reading OAuth client secret from {} (the backfill uses the same \
+                 OAuth setup as the scan; see the README)",
+                cfg.credentials.display()
+            )));
+        }
+    };
+    let auth = match yup_oauth2::InstalledFlowAuthenticator::builder(
+        secret,
+        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+    )
+    .persist_tokens_to_disk(cfg.tokens.clone())
+    .build()
+    .await
+    {
+        Ok(auth) => auth,
+        Err(e) => {
+            drop(writer_conn);
+            ingest::finish_run(
+                options,
+                run_id,
+                "failed",
+                Some("auth_required"),
+                Some(&e.to_string()),
+            )
+            .await
+            .ok();
+            return Err(anyhow::Error::new(e).context("building the OAuth authenticator"));
+        }
+    };
+    let auth_timeout = Duration::from_secs(env_or(
+        "GMAIL_STATS_AUTH_TIMEOUT",
+        DEFAULT_AUTH_TIMEOUT_SECS,
+    )?);
+    let scopes = ["https://www.googleapis.com/auth/gmail.readonly"];
+    if let Err(e) = consent_within(auth.token(&scopes), auth_timeout).await {
+        drop(writer_conn);
+        let msg = format!("{e:#}");
+        ingest::finish_run(
+            options,
+            run_id,
+            "failed",
+            Some(consent_error_kind(&msg)),
+            Some(&msg),
+        )
+        .await
+        .ok();
+        return Err(e);
+    }
+    let hub = Gmail::new(
+        hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build(
+            hyper_rustls::HttpsConnectorBuilder::new()
+                .with_native_roots()?
+                .https_or_http()
+                .enable_http2()
+                .build(),
+        ),
+        auth,
+    );
+
+    let mut read_conn = SqliteConnection::connect_with(options).await?;
+    let (write_tx, write_rx) = mpsc::channel::<ingest::BackfillMsg>(100);
+    let writer_handle = task::spawn(ingest::backfill_writer(writer_conn, write_rx, run_id));
+
+    let mut interval = tokio::time::interval(Duration::from_millis(rate_limit_ms));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let rate_limiter = Arc::new(Mutex::new(interval));
+    let hub_ref = &hub;
+    let rate_limiter_ref = &rate_limiter;
+    let fetch = move |mail_id: String| async move {
+        fetch_message_metadata_headers(
+            hub_ref,
+            &mail_id,
+            rate_limiter_ref,
+            BACKFILL_METADATA_HEADERS,
+        )
+        .await
+    };
+
+    let loop_result = backfill_scan_rows(
+        &mut read_conn,
+        &write_tx,
+        fetch_concurrency,
+        fetch,
+        cancel.as_ref(),
+    )
+    .await;
+
+    drop(write_tx);
+    let writer_result = match writer_handle.await {
+        Ok(result) => result,
+        Err(join_err) => {
+            let msg = format!("DB writer task panicked: {join_err:?}");
+            ingest::finish_run(options, run_id, "failed", Some("db"), Some(&msg))
+                .await
+                .ok();
+            anyhow::bail!("{msg}");
+        }
+    };
+
+    let outcome = match (loop_result, writer_result) {
+        (Ok(()), Ok(outcome)) => outcome,
+        (_, Err(writer_err)) => {
+            ingest::finish_run(
+                options,
+                run_id,
+                "failed",
+                Some("db"),
+                Some(&format!("{writer_err:#}")),
+            )
+            .await
+            .ok();
+            return Err(writer_err.context("DB writer task failed"));
+        }
+        (Err(e), Ok(outcome)) => {
+            if cancel.load(Ordering::Relaxed) {
+                // Shutdown fallout, not a real failure: everything committed
+                // so far is durable, and a re-run continues from it.
+                outcome
+            } else {
+                ingest::finish_run(
+                    options,
+                    run_id,
+                    "failed",
+                    Some(classify_scan_error(&e)),
+                    Some(&format!("{e:#}")),
+                )
+                .await
+                .ok();
+                return Err(e.context(
+                    "backfill stopped; re-run `gmail_stats scan --backfill-message-ids` \
+                     to continue where it left off",
+                ));
+            }
+        }
+    };
+
+    if cancel.load(Ordering::Relaxed) {
+        ingest::finish_run(options, run_id, "cancelled", None, None).await?;
+        println!(
+            "backfill cancelled cleanly; re-run `gmail_stats scan --backfill-message-ids` \
+             to continue where it left off"
+        );
+    } else {
+        ingest::finish_run(options, run_id, "done", None, None).await?;
+        println!(
+            "backfill finished: {} message(s) checked, {} Message-ID(s) recorded, \
+             {} without a Message-ID, {} cross-source duplicate count(s) collapsed",
+            outcome.examined, outcome.populated, outcome.missing_id, outcome.decremented
+        );
+    }
+    Ok(())
+}
+
+/// Iterate the unrepaired scan rows in keyset-paginated batches, fetch each
+/// message's metadata (bounded concurrency, shared rate limiter), and send
+/// the extracted Message-ID + sender to the backfill writer.
+///
+/// The cursor advances over mail_id, so rows dispatched but not yet committed
+/// by the writer are never selected twice within a run; across runs, repaired
+/// rows are non-NULL and drop out of the query entirely. Generic over the
+/// fetch function so the loop is testable with fabricated messages — the live
+/// path plugs in the scan's rate-limited/retrying metadata fetch.
+async fn backfill_scan_rows<F, Fut>(
+    read_conn: &mut SqliteConnection,
+    write_tx: &mpsc::Sender<ingest::BackfillMsg>,
+    fetch_concurrency: usize,
+    fetch: F,
+    cancel: &AtomicBool,
+) -> anyhow::Result<()>
+where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<Message>>,
+{
+    let mut dispatched = 0u64;
+    let mut cursor = String::new();
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        let batch: Vec<String> = sqlx::query_scalar(
+            "SELECT mail_id FROM seen_mails \
+             WHERE rfc_message_id IS NULL AND mail_id NOT LIKE 'mid:%' \
+             AND mail_id > ? ORDER BY mail_id LIMIT 500",
+        )
+        .bind(&cursor)
+        .fetch_all(&mut *read_conn)
+        .await?;
+        let Some(last) = batch.last() else {
+            return Ok(());
+        };
+        cursor = last.clone();
+        dispatched += batch.len() as u64;
+
+        let fetch_ref = &fetch;
+        stream::iter(batch.into_iter().map(Ok::<_, anyhow::Error>))
+            .try_for_each_concurrent(fetch_concurrency, move |mail_id| {
+                let write_tx = write_tx.clone();
+                async move {
+                    if cancel.load(Ordering::Relaxed) {
+                        return Ok(());
+                    }
+                    let message = fetch_ref(mail_id.clone())
+                        .await
+                        .with_context(|| format!("fetching metadata for message {mail_id}"))?;
+                    let sender = cleanup_sender(get_sender(&message)?);
+                    if verbose() {
+                        println!("backfill {mail_id}: sender {sender:?}");
+                    }
+                    write_tx
+                        .send(ingest::BackfillMsg {
+                            rfc_message_id: get_rfc_message_id(&message),
+                            mail_id,
+                            sender,
+                        })
+                        .await
+                        .map_err(|_| anyhow::anyhow!("DB writer task closed unexpectedly"))?;
+                    Ok(())
+                }
+            })
+            .await?;
+        if chatty() {
+            println!("backfill: {dispatched} message(s) fetched");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Sender extraction, shared by both ingestion modes
 // ---------------------------------------------------------------------------
 
@@ -1473,29 +1857,41 @@ fn cleanup_sender(sender: String) -> String {
     clean_sender
 }
 
-fn get_sender(message: &Message) -> anyhow::Result<String> {
-    // Header names are case-insensitive (RFC 5322); check candidates in
-    // priority order via the shared pick_sender.
-    let headers = message
+/// Find a header value by case-insensitive name (RFC 5322) in a fetched
+/// message's payload.
+fn find_header<'a>(message: &'a Message, name: &str) -> Option<&'a str> {
+    message
         .payload
         .as_ref()
         .and_then(|p| p.headers.as_deref())
-        .unwrap_or(&[]);
-    let find = |name: &str| {
-        headers.iter().find_map(|header| {
+        .unwrap_or(&[])
+        .iter()
+        .find_map(|header| {
             header
                 .name
                 .as_deref()
                 .filter(|n| n.eq_ignore_ascii_case(name))
                 .and(header.value.as_deref())
         })
-    };
+}
 
-    let sender = pick_sender(find("from"), find("return-path"));
+fn get_sender(message: &Message) -> anyhow::Result<String> {
+    // Check candidates in priority order via the shared pick_sender.
+    let sender = pick_sender(
+        find_header(message, "from"),
+        find_header(message, "return-path"),
+    );
     if sender.is_empty() && verbose() {
         println!("weird email without from header: {:?}", message.id);
     }
     Ok(sender)
+}
+
+/// The message's RFC Message-ID, normalized with the shared helper. Used by
+/// the scan when marking a message seen and by the backfill repair pass, so
+/// the same message always yields the same normalized id.
+fn get_rfc_message_id(message: &Message) -> Option<String> {
+    find_header(message, "message-id").and_then(ingest::normalize_rfc_message_id)
 }
 
 #[cfg(test)]
@@ -1685,6 +2081,35 @@ mod tests {
         assert_eq!(get_sender(&message).unwrap(), "bounce@example.com");
     }
 
+    // --- get_rfc_message_id ---
+
+    #[test]
+    fn get_rfc_message_id_normalizes_the_header() {
+        for (raw, want) in [
+            ("<m1@example.com>", Some("m1@example.com")),
+            ("m1@example.com", Some("m1@example.com")),
+            ("  <m1@example.com>  ", Some("m1@example.com")),
+            ("<>", None),
+        ] {
+            let message = message_with_headers(vec![header("Message-ID", Some(raw))]);
+            assert_eq!(
+                get_rfc_message_id(&message).as_deref(),
+                want,
+                "failed for {raw:?}"
+            );
+        }
+        // Case-insensitive header name, like every RFC 5322 header.
+        let message = message_with_headers(vec![header("MESSAGE-ID", Some("<m1@example.com>"))]);
+        assert_eq!(
+            get_rfc_message_id(&message).as_deref(),
+            Some("m1@example.com")
+        );
+        // Absent header (or no payload): None.
+        let message = message_with_headers(vec![header("Subject", Some("hi"))]);
+        assert_eq!(get_rfc_message_id(&message), None);
+        assert_eq!(get_rfc_message_id(&Message::default()), None);
+    }
+
     #[test]
     fn get_sender_falls_back_to_empty_string() {
         // Headers present but none relevant.
@@ -1777,6 +2202,22 @@ mod tests {
     }
 
     #[test]
+    fn backfill_flag_selects_the_repair_mode() {
+        assert_eq!(
+            run_cfg(&["scan", "--backfill-message-ids"], no_env).mode,
+            Mode::BackfillMessageIds
+        );
+        assert_eq!(
+            run_cfg(&["--backfill-message-ids"], no_env).mode,
+            Mode::BackfillMessageIds
+        );
+        assert_eq!(
+            run_cfg(&["--backfill-message-ids", "--quiet"], no_env).verbosity,
+            Verbosity::Quiet
+        );
+    }
+
+    #[test]
     fn invalid_invocations_are_rejected() {
         for args in [
             &["--quiet", "--verbose"][..],
@@ -1787,6 +2228,8 @@ mod tests {
             &["scan", "extra"][..],
             &["import", "a.mbox", "extra"][..],
             &["--db"][..],
+            &["scan", "--backfill-message-ids", "--resume", "3"][..],
+            &["import", "a.mbox", "--backfill-message-ids"][..],
         ] {
             let result = parse_args(args.iter().map(|s| s.to_string()), no_env);
             assert!(result.is_err(), "expected {args:?} to be rejected");
@@ -2142,6 +2585,135 @@ mod tests {
             consent_error_kind("Error 400: policy_enforced"),
             "policy_enforced"
         );
+    }
+
+    // --- backfill fetch loop (fabricated rows and messages; the live path
+    //     plugs the scan's rate-limited metadata fetch into the same loop) ---
+
+    /// A fake fetcher standing in for fetch_message_metadata_headers: returns
+    /// canned headers per Gmail id, exactly the shape format=metadata yields.
+    fn fabricated_fetcher(
+        mails: Vec<(&'static str, Option<&'static str>, &'static str)>,
+    ) -> impl Fn(String) -> std::future::Ready<anyhow::Result<Message>> {
+        move |mail_id: String| {
+            let found = mails.iter().find(|(id, _, _)| *id == mail_id);
+            std::future::ready(match found {
+                None => Err(anyhow::anyhow!("unexpected fetch for {mail_id}")),
+                Some((_, rfc, from)) => {
+                    let mut headers = vec![header("From", Some(from))];
+                    if let Some(rfc) = rfc {
+                        headers.push(header("Message-ID", Some(rfc)));
+                    }
+                    Ok(message_with_headers(headers))
+                }
+            })
+        }
+    }
+
+    /// End-to-end over fabricated rows: the loop selects exactly the bare
+    /// Gmail rows with NULL rfc_message_id (mid: rows and repaired rows are
+    /// untouched), fetches them, and the writer populates and collapses. A
+    /// second pass finds nothing to fetch.
+    #[tokio::test]
+    async fn backfill_loop_repairs_only_pending_scan_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = db_connect_options(&dir.path().join("stats.db"));
+        let mut conn = migrated_conn(&options).await;
+        // Historical mixed DB: g1 double-counted with the mid: row, g2 scan
+        // only, g3 has no Message-ID, g4 already repaired, plus a mid: row.
+        sqlx::query(
+            "INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES \
+             ('g1', NULL), ('g2', NULL), ('g3', NULL), \
+             ('g4', 'm4@example.com'), \
+             ('mid:<m1@example.com>', 'm1@example.com')",
+        )
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO senders (sender, mails_sent) VALUES \
+             ('a@example.com', 3), ('b@example.com', 2)",
+        )
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        let run_id = ingest::create_run(&mut conn, "backfill", None)
+            .await
+            .unwrap();
+
+        let (tx, rx) = mpsc::channel(16);
+        let writer = task::spawn(ingest::backfill_writer(conn, rx, run_id));
+        let fetch = fabricated_fetcher(vec![
+            ("g1", Some("<m1@example.com>"), "Alice <a@example.com>"),
+            ("g2", Some("<m2@example.com>"), "Bob <b@example.com>"),
+            ("g3", None, "Alice <a@example.com>"),
+        ]);
+        let mut read_conn = SqliteConnection::connect_with(&options).await.unwrap();
+        backfill_scan_rows(&mut read_conn, &tx, 4, &fetch, &AtomicBool::new(false))
+            .await
+            .unwrap();
+        drop(tx);
+        let outcome = writer.await.unwrap().unwrap();
+        assert_eq!(outcome.examined, 3);
+        assert_eq!(outcome.populated, 2);
+        assert_eq!(outcome.missing_id, 1);
+        assert_eq!(outcome.decremented, 1, "only g1 pairs with the mid: row");
+
+        // Counts collapsed exactly once; the untouched rows kept theirs.
+        assert_eq!(sender_count(&options, "a@example.com").await, Some(2));
+        assert_eq!(sender_count(&options, "b@example.com").await, Some(2));
+
+        // Second pass: nothing left to fetch — the fetcher would error on any
+        // call, so an empty run proves idempotency.
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        let run_id = ingest::create_run(&mut conn, "backfill", None)
+            .await
+            .unwrap();
+        let (tx, rx) = mpsc::channel(16);
+        let writer = task::spawn(ingest::backfill_writer(conn, rx, run_id));
+        let failing = fabricated_fetcher(vec![]);
+        backfill_scan_rows(&mut read_conn, &tx, 4, &failing, &AtomicBool::new(false))
+            .await
+            .unwrap();
+        drop(tx);
+        let outcome = writer.await.unwrap().unwrap();
+        assert_eq!(outcome.examined, 0, "a repaired database is a no-op");
+    }
+
+    /// Cancellation stops the loop between batches without error; whatever
+    /// was committed stays repaired for the next run.
+    #[tokio::test]
+    async fn backfill_loop_stops_on_cancel() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = db_connect_options(&dir.path().join("stats.db"));
+        let mut conn = migrated_conn(&options).await;
+        sqlx::query("INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES ('g1', NULL)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        let run_id = ingest::create_run(&mut conn, "backfill", None)
+            .await
+            .unwrap();
+        let (tx, rx) = mpsc::channel(16);
+        let writer = task::spawn(ingest::backfill_writer(conn, rx, run_id));
+        let fetch = fabricated_fetcher(vec![]);
+        let mut read_conn = SqliteConnection::connect_with(&options).await.unwrap();
+        backfill_scan_rows(&mut read_conn, &tx, 4, &fetch, &AtomicBool::new(true))
+            .await
+            .unwrap();
+        drop(tx);
+        let outcome = writer.await.unwrap().unwrap();
+        assert_eq!(outcome.examined, 0);
+        // The row is still pending for the next run.
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        let pending: i64 = sqlx::query_scalar(
+            "SELECT count(1) FROM seen_mails \
+             WHERE rfc_message_id IS NULL AND mail_id NOT LIKE 'mid:%'",
+        )
+        .fetch_one(&mut conn)
+        .await
+        .unwrap();
+        assert_eq!(pending, 1);
     }
 
     #[tokio::test]

--- a/src/webapp.rs
+++ b/src/webapp.rs
@@ -313,6 +313,9 @@ enum DbErrorKind {
     /// The file (or a table the query needs) doesn't exist.
     MissingFile,
     MissingTable,
+    /// A column this viewer knows about is missing: the database predates a
+    /// schema migration the ingester hasn't run yet.
+    MissingColumn,
     Busy,
     Other,
 }
@@ -323,6 +326,8 @@ fn classify_db_error(err: &sqlx::Error) -> DbErrorKind {
         DbErrorKind::MissingFile
     } else if lower.contains("no such table") {
         DbErrorKind::MissingTable
+    } else if lower.contains("no such column") {
+        DbErrorKind::MissingColumn
     } else if lower.contains("database is locked") || lower.contains("database is busy") {
         DbErrorKind::Busy
     } else {
@@ -356,37 +361,47 @@ async fn build_status(state: &AppState) -> Result<serde_json::Value, sqlx::Error
             Err(err) => match classify_db_error(&err) {
                 DbErrorKind::MissingFile => {
                     return Ok(status_document(
-                        state, "missing", None, None, false, lock_held,
+                        state,
+                        "missing",
+                        None,
+                        None,
+                        MixedSources::default(),
+                        lock_held,
                     ));
                 }
-                DbErrorKind::MissingTable => "empty",
+                DbErrorKind::MissingTable | DbErrorKind::MissingColumn => "empty",
                 DbErrorKind::Busy | DbErrorKind::Other => return Err(err),
             },
         };
 
     // Run rows. An old database without ingest_runs simply has no runs; the
     // ingester creates the table on its next start.
-    let (active_run, last_run, mixed_sources) = match fetch_runs_view(&state.pool).await {
+    let (active_run, last_run) = match fetch_runs_view(&state.pool).await {
         Ok(view) => view,
         Err(err) => match classify_db_error(&err) {
-            DbErrorKind::MissingFile | DbErrorKind::MissingTable => (None, None, false),
+            DbErrorKind::MissingFile | DbErrorKind::MissingTable | DbErrorKind::MissingColumn => {
+                (None, None)
+            }
             DbErrorKind::Busy | DbErrorKind::Other => return Err(err),
         },
     };
 
+    let mixed = match fetch_mixed_sources(&state.pool).await {
+        Ok(mixed) => mixed,
+        Err(err) => match classify_db_error(&err) {
+            DbErrorKind::MissingFile | DbErrorKind::MissingTable => MixedSources::default(),
+            DbErrorKind::MissingColumn | DbErrorKind::Busy | DbErrorKind::Other => return Err(err),
+        },
+    };
+
     Ok(status_document(
-        state,
-        db,
-        active_run,
-        last_run,
-        mixed_sources,
-        lock_held,
+        state, db, active_run, last_run, mixed, lock_held,
     ))
 }
 
 async fn fetch_runs_view(
     pool: &SqlitePool,
-) -> Result<(Option<SqliteRow>, Option<SqliteRow>, bool), sqlx::Error> {
+) -> Result<(Option<SqliteRow>, Option<SqliteRow>), sqlx::Error> {
     let active = sqlx::query(
         "SELECT * FROM ingest_runs \
          WHERE state NOT IN ('done', 'failed', 'cancelled', 'abandoned') \
@@ -401,16 +416,69 @@ async fn fetch_runs_view(
     )
     .fetch_optional(pool)
     .await?;
-    // Interim mixed-sources caution (removed by Phase D's exact dedupe): true
-    // once more than one source has actually contributed rows — completed, or
-    // got far enough to add new messages before stopping.
-    let mixed: i64 = sqlx::query_scalar(
-        "SELECT COUNT(DISTINCT source) FROM ingest_runs \
-         WHERE state = 'done' OR messages_new > 0",
+    Ok((active, last))
+}
+
+/// The cross-source dedupe repair state (issue #26 Phase D).
+#[derive(Debug, Default, PartialEq, Eq)]
+struct MixedSources {
+    /// True when both seen_mails keyspaces are present (bare Gmail ids from
+    /// API scans and `mid:` rows from mbox imports) AND at least one scan row
+    /// has no recorded Message-ID — i.e. counts may still contain
+    /// cross-source duplicates that `scan --backfill-message-ids` would
+    /// collapse. Once the backfill has repaired every scan row this turns
+    /// false and the UI banner disappears.
+    mixed_unrepaired: bool,
+    /// How many API-scan rows still lack a Message-ID (the rows the backfill
+    /// would fetch). Reported for UI copy; 0 once repaired.
+    unrepaired_count: i64,
+}
+
+async fn fetch_mixed_sources(pool: &SqlitePool) -> Result<MixedSources, sqlx::Error> {
+    let result = sqlx::query(
+        "SELECT \
+           EXISTS(SELECT 1 FROM seen_mails WHERE mail_id LIKE 'mid:%') AS has_mid, \
+           EXISTS(SELECT 1 FROM seen_mails WHERE mail_id NOT LIKE 'mid:%') AS has_bare, \
+           (SELECT count(1) FROM seen_mails \
+            WHERE mail_id NOT LIKE 'mid:%' AND rfc_message_id IS NULL) AS unrepaired",
     )
     .fetch_one(pool)
-    .await?;
-    Ok((active, last, mixed >= 2))
+    .await;
+    let (has_mid, has_bare, unrepaired) = match result {
+        Ok(row) => (
+            row.try_get::<i64, _>("has_mid").unwrap_or(0) != 0,
+            row.try_get::<i64, _>("has_bare").unwrap_or(0) != 0,
+            row.try_get::<i64, _>("unrepaired").unwrap_or(0),
+        ),
+        // A pre-Phase-D database has no rfc_message_id column yet, so every
+        // scan row counts as unrepaired: running the (new) ingester binary
+        // migrates the schema, and its backfill performs the repair.
+        Err(err) if matches!(classify_db_error(&err), DbErrorKind::MissingColumn) => {
+            let row = sqlx::query(
+                "SELECT \
+                   EXISTS(SELECT 1 FROM seen_mails WHERE mail_id LIKE 'mid:%') AS has_mid, \
+                   EXISTS(SELECT 1 FROM seen_mails WHERE mail_id NOT LIKE 'mid:%') AS has_bare, \
+                   (SELECT count(1) FROM seen_mails \
+                    WHERE mail_id NOT LIKE 'mid:%') AS unrepaired",
+            )
+            .fetch_one(pool)
+            .await?;
+            (
+                row.try_get::<i64, _>("has_mid").unwrap_or(0) != 0,
+                row.try_get::<i64, _>("has_bare").unwrap_or(0) != 0,
+                row.try_get::<i64, _>("unrepaired").unwrap_or(0),
+            )
+        }
+        Err(err) => return Err(err),
+    };
+    if has_mid && has_bare && unrepaired > 0 {
+        Ok(MixedSources {
+            mixed_unrepaired: true,
+            unrepaired_count: unrepaired,
+        })
+    } else {
+        Ok(MixedSources::default())
+    }
 }
 
 fn status_document(
@@ -418,7 +486,7 @@ fn status_document(
     db: &str,
     active_run: Option<SqliteRow>,
     last_run: Option<SqliteRow>,
-    mixed_sources: bool,
+    mixed: MixedSources,
     lock_held: Option<bool>,
 ) -> serde_json::Value {
     // Viewer-derived rate/ETA from successive observations of the active
@@ -471,7 +539,8 @@ fn status_document(
         "active_run": active_run.as_ref().map(run_to_json),
         "last_run": last_run.as_ref().map(run_to_json),
         "owns_active_run": owns_active_run,
-        "mixed_sources": mixed_sources,
+        "mixed_sources": mixed.mixed_unrepaired,
+        "unrepaired_count": mixed.unrepaired_count,
         "rate_per_sec": rate_per_sec,
         "eta_seconds": eta_seconds,
         "csrf_token": state.csrf_token,
@@ -643,7 +712,7 @@ async fn build_runs(pool: &SqlitePool, limit: i64) -> Result<serde_json::Value, 
         // has no run history; this endpoint powers a strip, not a diagnosis.
         Err(err) => match classify_db_error(&err) {
             DbErrorKind::MissingFile | DbErrorKind::MissingTable => Vec::new(),
-            DbErrorKind::Busy | DbErrorKind::Other => return Err(err),
+            DbErrorKind::MissingColumn | DbErrorKind::Busy | DbErrorKind::Other => return Err(err),
         },
     };
     let runs: Vec<serde_json::Value> = rows.iter().map(run_to_json).collect();
@@ -1442,7 +1511,7 @@ mod tests {
     async fn status_with_active_and_finished_runs() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = migrated_db(&dir).await;
-        exec(&db_path, "INSERT INTO seen_mails VALUES ('m1')").await;
+        exec(&db_path, "INSERT INTO seen_mails (mail_id) VALUES ('m1')").await;
         exec(
             &db_path,
             "INSERT INTO ingest_runs \
@@ -1481,28 +1550,101 @@ mod tests {
         assert!(body["now_unix"].as_u64().unwrap() > 0);
     }
 
+    /// mixed_sources means "both keyspaces present AND at least one scan row
+    /// still lacks its Message-ID": single-source databases never trigger it,
+    /// an unrepaired mix does (with the count the UI copy needs), and a
+    /// backfilled mix does not.
     #[tokio::test]
-    async fn status_mixed_sources_flags_dual_source_databases() {
+    async fn status_mixed_sources_tracks_keyspaces_and_repair_state() {
+        // Single source (scan only), even unrepaired: not mixed.
         let dir = tempfile::tempdir().unwrap();
         let db_path = migrated_db(&dir).await;
-        exec(&db_path, "INSERT INTO seen_mails VALUES ('m1')").await;
         exec(
             &db_path,
-            "INSERT INTO ingest_runs (run_id, source, state, started_at_unix, updated_at_unix, \
-             messages_new) VALUES (1, 'gmail_api', 'done', 100, 150, 10)",
+            "INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES \
+             ('g1', NULL), ('g2', NULL)",
         )
         .await;
         let (_, body) = get_json(app_for(&db_path), "/api/status").await;
         assert_eq!(body["mixed_sources"], false);
+        assert_eq!(body["unrepaired_count"], 0);
 
+        // Both keyspaces with unrepaired scan rows: mixed, count exposed.
         exec(
             &db_path,
-            "INSERT INTO ingest_runs (run_id, source, state, started_at_unix, updated_at_unix, \
-             messages_new) VALUES (2, 'mbox', 'done', 200, 250, 3)",
+            "INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES \
+             ('mid:<m1@example.com>', 'm1@example.com')",
         )
         .await;
         let (_, body) = get_json(app_for(&db_path), "/api/status").await;
         assert_eq!(body["mixed_sources"], true);
+        assert_eq!(body["unrepaired_count"], 2);
+
+        // Repaired (every scan row has a Message-ID or the '' sentinel for
+        // "fetched, has none"): the banner condition clears.
+        exec(
+            &db_path,
+            "UPDATE seen_mails SET rfc_message_id = 'm2@example.com' WHERE mail_id = 'g1'",
+        )
+        .await;
+        exec(
+            &db_path,
+            "UPDATE seen_mails SET rfc_message_id = '' WHERE mail_id = 'g2'",
+        )
+        .await;
+        let (_, body) = get_json(app_for(&db_path), "/api/status").await;
+        assert_eq!(body["mixed_sources"], false);
+        assert_eq!(body["unrepaired_count"], 0);
+    }
+
+    /// Import-only databases are never "mixed", repaired or not.
+    #[tokio::test]
+    async fn status_mixed_sources_false_for_import_only_databases() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = migrated_db(&dir).await;
+        exec(
+            &db_path,
+            "INSERT INTO seen_mails (mail_id, rfc_message_id) VALUES \
+             ('mid:<m1@example.com>', 'm1@example.com'), ('mid:<m2@example.com>', 'm2@example.com')",
+        )
+        .await;
+        let (_, body) = get_json(app_for(&db_path), "/api/status").await;
+        assert_eq!(body["mixed_sources"], false);
+        assert_eq!(body["unrepaired_count"], 0);
+    }
+
+    /// A pre-Phase-D database (no rfc_message_id column) that mixed sources:
+    /// every scan row counts as unrepaired, and the status must not 5xx.
+    #[tokio::test]
+    async fn status_mixed_sources_handles_a_pre_phase_d_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("old.db");
+        let options = SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true);
+        let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
+        sqlx::query("CREATE TABLE seen_mails (mail_id string)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE senders (sender string, mails_sent int)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO seen_mails (mail_id) VALUES \
+             ('g1'), ('g2'), ('g3'), ('mid:<m1@example.com>')",
+        )
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        conn.close().await.ok();
+
+        let (status, body) = get_json(app_for(&db_path), "/api/status").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["db"], "ready");
+        assert_eq!(body["mixed_sources"], true);
+        assert_eq!(body["unrepaired_count"], 3);
     }
 
     #[tokio::test]

--- a/tests/frontend/harness.py
+++ b/tests/frontend/harness.py
@@ -16,6 +16,8 @@ Scenarios:
   owns_true   owned run: Log renders ring-buffer lines, Cancel POSTs w/ CSRF
   auth_good   accounts.google.com auth_url renders a safe link
   auth_evil   any other auth_url renders as inert text (no link)
+  mixed_unrepaired  mixed_sources: banner names the backfill command + count
+  mixed_repaired    repaired database: no banner
 
 Run:  python3 tests/frontend/harness.py
 Requires Google Chrome (path override: CHROME env var). Exits non-zero on any
@@ -68,6 +70,7 @@ def base_status(**overrides):
         "last_run": None,
         "owns_active_run": False,
         "mixed_sources": False,
+        "unrepaired_count": 0,
         "rate_per_sec": None,
         "eta_seconds": None,
         "csrf_token": TOKEN,
@@ -141,6 +144,12 @@ SCENARIOS = {
             ingest_lock_held=True,
             owns_active_run=True,
         ),
+    },
+    "mixed_unrepaired": {
+        "status": base_status(mixed_sources=True, unrepaired_count=1234),
+    },
+    "mixed_repaired": {
+        "status": base_status(),
     },
 }
 
@@ -349,6 +358,25 @@ def main():
                 "hostile URL shown as inert text",
                 failures,
             )
+        elif name == "mixed_unrepaired":
+            check(not results["bannerHidden"], "mixed banner visible when unrepaired", failures)
+            check(
+                results["command"] == "cargo run -- scan --backfill-message-ids",
+                f"banner names the exact backfill command ({results['command']!r})",
+                failures,
+            )
+            check(
+                "1,234" in results["text"] or "1234" in results["text"],
+                "banner mentions the unrepaired count",
+                failures,
+            )
+            check(
+                "duplicate" in results["text"].lower(),
+                "banner explains cross-source duplicates",
+                failures,
+            )
+        elif name == "mixed_repaired":
+            check(results["bannerHidden"], "mixed banner absent when repaired", failures)
 
     print()
     if failures:

--- a/tests/frontend/test_driver.js
+++ b/tests/frontend/test_driver.js
@@ -111,6 +111,25 @@ async function run() {
     return;
   }
 
+  if (SCENARIO === "mixed_unrepaired" || SCENARIO === "mixed_repaired") {
+    await waitFor(
+      () => !document.getElementById("stats").classList.contains("hidden"),
+      "stats view",
+    );
+    if (SCENARIO === "mixed_unrepaired") {
+      await waitFor(() => !hidden("mixed-banner"), "mixed banner");
+    } else {
+      await sleep(600); // give the status poll time to render (or not) the banner
+    }
+    report({
+      scenario: SCENARIO,
+      bannerHidden: hidden("mixed-banner"),
+      text: document.getElementById("mixed-text").textContent,
+      command: document.getElementById("mixed-command").textContent,
+    });
+    return;
+  }
+
   if (SCENARIO === "auth_good" || SCENARIO === "auth_evil") {
     await waitFor(() => !hidden("run-auth"), "auth slot");
     const slot = document.getElementById("run-auth");

--- a/web/app.css
+++ b/web/app.css
@@ -211,6 +211,17 @@ tr.hidden-row td.act { opacity: 1; }
   margin: 0 0 1rem;
   font-size: 0.9rem;
 }
+.banner-command {
+  display: block;
+  margin-top: 0.4rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg) 8%, var(--card));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  user-select: all;
+  -webkit-user-select: all;
+}
 #generated-at.stale { opacity: 0.45; }
 
 .cards { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1rem 0; }

--- a/web/app.js
+++ b/web/app.js
@@ -154,6 +154,7 @@ function shouldOnboard() {
 function sourceLabel(source) {
   if (source === "mbox") return "Takeout import";
   if (source === "gmail_api") return "Gmail scan";
+  if (source === "backfill") return "Message-ID backfill";
   return source ? String(source) : "Ingestion";
 }
 
@@ -607,10 +608,28 @@ function renderIngest() {
   }
   renderPill();
   renderPanel();
-  document
-    .getElementById("mixed-banner")
-    .classList.toggle("hidden", !(ingest.status && ingest.status.mixed_sources === true));
+  renderMixedBanner();
   reconcileMainView();
+}
+
+// Cross-source repair caution: shown only while the database mixes scan and
+// import keyspaces AND some scanned messages still lack their Message-ID
+// (mixed_sources from /api/status). Names the exact repair command; once
+// `scan --backfill-message-ids` has run, mixed_sources turns false and the
+// banner disappears. All content via textContent.
+function renderMixedBanner() {
+  const status = ingest.status;
+  const mixed = Boolean(status && status.mixed_sources === true);
+  document.getElementById("mixed-banner").classList.toggle("hidden", !mixed);
+  if (!mixed) return;
+  const n = Number(status.unrepaired_count) || 0;
+  const counted = n > 0 ? `${n.toLocaleString()} scanned message(s)` : "some scanned messages";
+  document.getElementById("mixed-text").textContent =
+    `Counts may include cross-source duplicates: this database mixes scan and ` +
+    `import, and ${counted} have no recorded Message-ID yet. Repair once ` +
+    `(idempotent, resumable) with:`;
+  document.getElementById("mixed-command").textContent =
+    "cargo run -- scan --backfill-message-ids";
 }
 
 function scheduleStatusPoll(delayMs) {

--- a/web/index.html
+++ b/web/index.html
@@ -109,8 +109,8 @@
 
   <section id="stats" class="hidden">
     <div id="mixed-banner" class="warn-banner hidden">
-      Counts may include duplicates across scan + import: both sources have
-      written to this database, and exact cross-source dedupe hasn't run yet.
+      <span id="mixed-text"></span>
+      <code id="mixed-command" class="banner-command"></code>
     </div>
     <div class="tiles">
       <div class="tile">


### PR DESCRIPTION
Closes #32 — the final committed phase (Phase D) of #26: exact cross-source dedupe via `rfc_message_id`, and retirement of the interim mixed-sources banner.

## What's here

**Schema (migration 2, `user_version` 2).** `seen_mails` gains a nullable `rfc_message_id` column with a non-unique index. `mid:` rows are populated during the migration itself from the Message-ID embedded in their key; bare Gmail rows stay NULL until backfilled. A database from a newer binary is still refused. Message-IDs are normalized by one shared helper (trim whitespace, strip one enclosing `<>`, case preserved) used by the scanner, the importer, the migration, and the backfill.

**Dual-direction check-before-increment.** Both ingesters record the normalized Message-ID when marking a message seen; inside the same single-writer transaction, a newly inserted row whose Message-ID already exists on any other `seen_mails` row is marked seen (idempotency intact) but not counted — neither the sender count nor the run's `messages_new` moves (there was no room in the run row schema for a distinct deduped counter, so deduped messages read as seen-not-new). Works in both directions: scan-after-import and import-after-scan. Messages without a Message-ID keep the old behavior (counted, NULL column).

**`scan --backfill-message-ids`.** A first-class ingest run: takes the flock, writes a run row (`source: backfill`, with heartbeats and `total_estimate`), stops cleanly on SIGTERM/SIGINT, honors `--quiet`/`--verbose`, and shows up in the web viewer's progress UI like any other run. It iterates bare-Gmail-id rows with NULL `rfc_message_id` in keyset-paginated batches (cursor over `mail_id`, so writer-lag can never re-select in-flight rows), fetches `format=metadata` restricted to Message-ID/From/Return-Path through the scan's existing rate-limited, retrying fetch machinery, and populates the column.

The collapse of historical double counts is fused into the populate rather than run as a separate phase: each row's duplicate check and sender decrement (never below zero) commit atomically with its populate. That is what makes partial completion + resume exact — a killed run leaves every row either fully repaired or untouched, re-running the same command continues with precisely the remainder, and a second run over a repaired database finds nothing to do and never touches the network. Rows fetched and found to have no Message-ID get an `''` marker so they are not re-fetched (forward ingestion keeps NULL for such messages, per the issue; the marker exists only so the backfill terminates). No `--resume` flag: resumption is inherent, and combining the two is rejected.

**Banner retirement.** `mixed_sources` in `/api/status` now means "both keyspaces present AND at least one bare-Gmail-id row has NULL `rfc_message_id`", computed from `seen_mails` itself, with `unrepaired_count` exposed for the UI copy. A pre-Phase-D database (no column yet) counts every scan row as unrepaired and does not 5xx the read-only viewer. The banner explains that counts may include cross-source duplicates and shows the exact backfill command in a copyable code block (textContent only); it disappears once repaired. README's "don't mix both modes" warning is replaced with dedupe + backfill documentation.

## Honest limitation

The live Gmail fetch inside the backfill was **not run** — it needs real OAuth credentials, which this change never touches. It shares `fetch_message`'s machinery (now parameterized to add `format=metadata` + `metadataHeaders`) and the scan's auth path, and the fetch loop is generic over the fetcher, so everything downstream of the network — iteration/pagination, header extraction, populate, collapse, resume — is covered by tests against fabricated rows and messages. `stats.db`/`credentials.json`/`tokencache.json` in the repo root are untouched.

## Tests

- Migration: fresh DB, v0 upgrade, v1 upgrade with `mid:` population, newer-version refusal, re-run no-op
- Normalization: `<id@host>` / `id@host` / whitespace / case / unbalanced-bracket variants
- Forward dedupe both directions with fabricated rows: overlapping scan+import sets count the true union; id-less messages still counted; replays add zero
- Backfill: fixture DB with historical double counts repaired exactly once; never below zero; interrupted-midway resume; second run no-op; loop selects only pending bare rows; cancel between batches
- Status: single source / mixed unrepaired (+count) / mixed repaired / import-only / pre-Phase-D column-less DB
- Front-end (headless-Chrome harness, 8 scenarios incl. 2 new): banner shows the command when unrepaired, absent when repaired

Gates: `cargo build`, `cargo test` (49+41+13 pass), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `python3 demo/build_demo.py` into a temp dir (all anchors intact), `python3 tests/frontend/harness.py` (all scenarios pass).
